### PR TITLE
Revert "Update Helm release external-dns to v4.9.3"

### DIFF
--- a/services/dev/external-dns-values.yaml
+++ b/services/dev/external-dns-values.yaml
@@ -9,6 +9,6 @@ spec:
     spec:
       # renovate: registryUrl=https://charts.bitnami.com/bitnami
       chart: external-dns
-      version: 4.9.3
+      version: 4.9.2
   values:
     domainFilters: ["dev.mrv.thebends.org"]


### PR DESCRIPTION
Reverts allenporter/k8s-gitops#30

external-dns is crashing