### PR TITLE
Revert "Update Helm release rook-ceph to v1.6.0"

### DIFF
--- a/infrastructure/rook-ceph/rook-ceph/release.yaml
+++ b/infrastructure/rook-ceph/rook-ceph/release.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       # renovate: registryUrl=https://charts.rook.io/release
       chart: rook-ceph
-      version: v1.6.0
+      version: v1.5.9
       sourceRef:
         kind: HelmRepository
         name: rook-release


### PR DESCRIPTION
Reverts allenporter/k8s-gitops#95

Currently causing rook-ceph crash
```
$ kubectl logs rook-ceph-operator-54b5dff7c5-fnjhk -n rook-ceph
2021-04-17 15:10:35.968510 E | operator: gave up to run the operator. failed to run the controller-runtime manager: no matches for kind "CephFilesystemMirror" in version "ceph.rook.io/v1"
failed to run operator
: failed to run the controller-runtime manager: no matches for kind "CephFilesystemMirror" in version "ceph.rook.io/v1"
```
