### PR TITLE
Ignore transient errors in discord notifications

### DIFF
--- a/monitoring/base/flux-monitoring/info.yaml
+++ b/monitoring/base/flux-monitoring/info.yaml
@@ -13,3 +13,9 @@ spec:
       name: '*'
     - kind: HelmRelease
       name: '*'
+  exclusionList:
+    # Ignore transient failures on external dependencies and rely on prometheus
+    # alerting for stuck reconiciliations
+    - "error.*lookup github\\.com"
+    - "waiting.*socket"
+    - "TLS handshake timeout"


### PR DESCRIPTION
Issue #242
See https://github.com/billimek/k8s-gitops/blob/master/flux-system-extra/discord-notifications/alerts.yaml#L16-L17
See https://fluxcd.io/docs/components/notification/alert/ example