### PR TITLE
Rollback unifi to v6.5.53

### DIFF
--- a/network/prod/unifi-values.yaml
+++ b/network/prod/unifi-values.yaml
@@ -13,7 +13,7 @@ spec:
   values:
     image:
       repository: jacobalberty/unifi
-      tag: v6.5.54
+      tag: v6.5.53
     livenessProbe:
       initialDelaySeconds: 60
       periodSeconds: 30

--- a/renovate.json5
+++ b/renovate.json5
@@ -36,6 +36,7 @@
       "automergeType": "branch",
       "additionalBranchPrefix": "dev-",
       "matchUpdateTypes": ["minor", "patch", "digest"],
+      "excludePackagePatterns": [".*unifi.*"],
     },
     {
       "description": "dev: Major packages updated weekly",

--- a/renovate.json5
+++ b/renovate.json5
@@ -36,7 +36,10 @@
       "automergeType": "branch",
       "additionalBranchPrefix": "dev-",
       "matchUpdateTypes": ["minor", "patch", "digest"],
-      "excludePackagePatterns": [".*unifi.*"],
+      "excludePackagePatterns": [
+          # Skip updates until https://github.com/jacobalberty/unifi-docker/issues/495 is resolved
+          ".*unifi.*"
+      ],
     },
     {
       "description": "dev: Major packages updated weekly",


### PR DESCRIPTION
Rollback unifi to v6.5.53 until issue https://github.com/jacobalberty/unifi-docker/issues/495 is resolved

However, do want to get this upgrade in to resolve the CVE.