### PR TITLE
Fix comment syntax in renovate config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -37,7 +37,7 @@
       "additionalBranchPrefix": "dev-",
       "matchUpdateTypes": ["minor", "patch", "digest"],
       "excludePackagePatterns": [
-          # Skip updates until https://github.com/jacobalberty/unifi-docker/issues/495 is resolved
+          // Skip updates until https://github.com/jacobalberty/unifi-docker/issues/495 is resolved
           ".*unifi.*"
       ],
     },


### PR DESCRIPTION
Fix renovate configuration comment syntax. Note this is not found by renovate config validator!