### PR TITLE
Update pull policy to `Always` since unifi bad image was overwritten

### DIFF
--- a/network/prod/unifi-values.yaml
+++ b/network/prod/unifi-values.yaml
@@ -14,6 +14,8 @@ spec:
     image:
       repository: jacobalberty/unifi
       tag: v6.5.54
+      # Due to force overwrite of 6.5.54 in https://github.com/jacobalberty/unifi-docker/issues/493
+      pullPolicy: Always
     livenessProbe:
       initialDelaySeconds: 60
       periodSeconds: 30


### PR DESCRIPTION
Update pull policy to `Always` since the existing version label that is bad was updated in place.

See discussion in https://github.com/jacobalberty/unifi-docker/issues/493