### PR TITLE
Revert rook-ceph and update renovate rules

### DIFF
--- a/infrastructure/dev/rook-ceph-values.yaml
+++ b/infrastructure/dev/rook-ceph-values.yaml
@@ -10,4 +10,4 @@ spec:
     spec:
       # renovate: registryUrl=https://charts.rook.io/release
       chart: rook-ceph
-      version: v1.8.1
+      version: v1.7.9

--- a/renovate.json5
+++ b/renovate.json5
@@ -26,6 +26,13 @@
     "fileMatch": [".*(release|values|components)\\.yaml$"],
   },
   "packageRules": [
+    {
+      "packagePatterns": [
+          // https://github.com/allenporter/k8s-gitops/issues/445
+          "^rook-ceph.*"
+      ],
+      "enabled": false,
+    },
     // Use different update schedules for dev and prod based on the type of
     // patch. Note that each rule needs its own brach prefix in order to
     // have a working space for evaluating the rules independently.
@@ -43,10 +50,6 @@
       "extends": ["schedule:weekends"],
       "additionalBranchPrefix": "dev-major",
       "matchUpdateTypes": ["major"],
-      "excludePackagePatterns": [
-          // https://github.com/allenporter/k8s-gitops/issues/445
-          "^rook-ceph.*"
-      ],
     },
     {
       "description": "prod: Patches are automatic after 1 day",


### PR DESCRIPTION
Rule for blocking updates did not seem to work.
Issue #445 is still pending