### PR TITLE
Enable mariadb for Home Assistant

### DIFF
--- a/home/dev/home-assistant-values.yaml
+++ b/home/dev/home-assistant-values.yaml
@@ -46,3 +46,14 @@ spec:
             - secretName: vscode-home-assistant-tls
               hosts:
                 - vscode-ha.dev.mrv.thebends.org
+
+    mariadb:
+      enabled: true
+      auth:
+        database: home-assistant
+        username: home-assistant
+        password: ${HOME_ASSISTANT_MARIADB_USER_PWD}
+        rootPassword: ${HOME_ASSISTANT_MARIADB_ROOT_PWD}
+      primary:
+        persistence:
+          enabled: true

--- a/settings/dev/cluster-secrets.yaml
+++ b/settings/dev/cluster-secrets.yaml
@@ -2,6 +2,8 @@
 apiVersion: v1
 data:
     HOME_ASSISTANT_POSTGRESQL_PWD: ENC[AES256_GCM,data:JMKaCu2ZPv3V/0ApguflAg==,iv:1oBuNMd5SuNOAEYgc1zzt7INEWJKFjIF0C5wXqoRcK0=,tag:0F9mnwWTfnsaW5YTjbNzdw==,type:str]
+    HOME_ASSISTANT_MARIADB_USER_PWD: ENC[AES256_GCM,data:Li2cVmQaXizlHw==,iv:jX75ZQHUxc5qe0fSittr+lUdTTaKRXzhJLSNaYyGPt4=,tag:X1m5eoRLHkpbOcCc+KiG/w==,type:str]
+    HOME_ASSISTANT_MARIADB_ROOT_PWD: ENC[AES256_GCM,data:v8BYP0Z18I9+TQ==,iv:jIiUH9ToF0yVSoqG1+UNFs+ock4zMcVFahrcQBHRKpA=,tag:74Ezy0nQiVVOQM4A6/AOjw==,type:str]
 kind: Secret
 metadata:
     creationTimestamp: null
@@ -13,8 +15,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2021-08-28T00:09:38Z"
-    mac: ENC[AES256_GCM,data:7Wcs1a72M+DwE/9g5a1142HqjBhpbjkpFGhtekkKjoECJbimHP0MluF2v4IIabvaTcEFTmD0YUMfu/hNvynKKsupbO9UdZNWuVAxpSqaiuqpOTct6q4sBb4AhO/xldC8m+MCX8wwYwpz2gsJezzfHNpY+ewkH032g6jP4+j4lNM=,iv:cFUnhOX1EvpOAAQ2jBYoKFv1Iqrioj4+pM6/CvM4fy4=,tag:usiW+xdoSwYx0hLGY6hL3w==,type:str]
+    lastmodified: "2022-01-08T21:28:40Z"
+    mac: ENC[AES256_GCM,data:njGk2XXSO9UiQ3/Nq0FUb3YWyJl2KE2T0UQ8diOJ5idt3TXpMsKQ9o0OiySfvMf5CSqGqK5RVajqjiG+hS6OkulzbcECht1tVgRqw/iVWNNZMGT6oizc5uBdpGOIZMwRph0gaSXE+wbaYmPcX6TNIx2yl7embb2jaar1u+Uvrq8=,iv:D3czkkVC45UCKZ+hlI2EkS52q+fvh+7ZiXqrI/LFGPA=,tag:JD+K+viscqqBEKY6MsYmAQ==,type:str]
     pgp:
         - created_at: "2021-08-27T23:31:45Z"
           enc: |


### PR DESCRIPTION
Enable mariadb for Home Assistant since upgrade of Postgreql looks to be significant effort, compared to mariadb going forward.
Issue #480