### PR TITLE
Enable mqtt for teslamate

### DIFF
--- a/home/base/teslamate/release.yaml
+++ b/home/base/teslamate/release.yaml
@@ -34,7 +34,8 @@ spec:
       DATABASE_NAME: "teslamate"
       DATABASE_USER: "postgres"
       DATABASE_HOST: "teslamate-postgresql"
-      DISABLE_MQTT: "true"
+      DISABLE_MQTT: "false"
+      MQTT_HOST: "mosquitto.mqtt"
     envValueFrom:
       DATABASE_PASS:
         secretKeyRef:


### PR DESCRIPTION
Enable mqtt for teslamate for use in home assistant