### PR TITLE
Add Adguard Home dev instance

### DIFF
--- a/clusters/dev/network.yaml
+++ b/clusters/dev/network.yaml
@@ -14,3 +14,10 @@ spec:
     name: flux-system
   path: ./network/dev
   prune: true
+  postBuild:
+    substitute: {}
+    substituteFrom:
+      - kind: ConfigMap
+        name: cluster-settings
+      - kind: Secret
+        name: cluster-secrets

--- a/network/base/adguard-home/kustomization.yaml
+++ b/network/base/adguard-home/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: adguard-home
+resources:
+  - namespace.yaml
+  - release.yaml

--- a/network/base/adguard-home/namespace.yaml
+++ b/network/base/adguard-home/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: adguard-home

--- a/network/base/adguard-home/release.yaml
+++ b/network/base/adguard-home/release.yaml
@@ -38,6 +38,15 @@ spec:
       data:
         enabled: true
 
+    service:
+      dns-tcp:
+        annotations:
+            metallb.universe.tf/allow-shared-ip: adguard-home-svc
+      dns-udp:
+        annotations:
+            metallb.universe.tf/allow-shared-ip: adguard-home-svc
+
+
     ingress:
       main:
         enabled: true

--- a/network/base/adguard-home/release.yaml
+++ b/network/base/adguard-home/release.yaml
@@ -1,0 +1,47 @@
+# yamllint disable-file
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: adguard-home
+  namespace: adguard-home
+spec:
+  releaseName: adguard-home
+  chart:
+    spec:
+      chart: adguard-home
+      sourceRef:
+        kind: HelmRepository
+        name: k8s-at-home
+        namespace: flux-system
+  interval: 5m
+  install:
+    remediation:
+      retries: 3
+  test:
+    enable: false
+  # https://github.com/k8s-at-home/charts/blob/master/charts/stable/adguard-home/values.yaml
+  values:
+    env:
+      TZ: "America/Los_Angeles"
+
+    image:
+      repository: adguard/adguardhome
+      tag: v0.108.0-b.3
+
+    config:
+      parental_enabled: true
+      safesearch_enabled: true
+      safebrowsing_enabled: true
+
+    persistence:
+      data:
+        enabled: true
+
+    ingress:
+      main:
+        enabled: true
+        annotations:
+          kubernetes.io/ingress.class: haproxy
+          cert-manager.io/cluster-issuer: letsencrypt
+          hajimari.io/icon: adguard-home

--- a/network/dev/adguard-home-values.yaml
+++ b/network/dev/adguard-home-values.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: adguard-home
+  namespace: adguard-home
+spec:
+  chart:
+    spec:
+      chart: adguard-home
+      version: 5.2.0
+  values:
+    service:
+      dns-tcp:
+        loadBalancerIP: 10.10.24.12
+      dns-udp:
+        loadBalancerIP: 10.10.24.12
+
+    ingress:
+      main:
+        annotations:
+          external-dns.alpha.kubernetes.io/hostname: adguard-home.dev.mrv.thebends.org.
+          external-dns.alpha.kubernetes.io/target: prx02.dev.mrv.thebends.org.
+        hosts:
+          - host: adguard-home.dev.mrv.thebends.org
+            paths:
+              - path: /
+                pathType: Prefix
+        tls:
+          - secretName: adguard-home-tls
+            hosts:
+              - adguard-home.dev.mrv.thebends.org

--- a/network/dev/adguard-home-values.yaml
+++ b/network/dev/adguard-home-values.yaml
@@ -12,9 +12,9 @@ spec:
   values:
     service:
       dns-tcp:
-        loadBalancerIP: 10.10.24.12
+        loadBalancerIP: ${ADGUARD_HOME_IP}
       dns-udp:
-        loadBalancerIP: 10.10.24.12
+        loadBalancerIP: ${ADGUARD_HOME_IP}
 
     ingress:
       main:

--- a/network/dev/kustomization.yaml
+++ b/network/dev/kustomization.yaml
@@ -3,5 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base/pihole
+  - ../base/adguard-home
 patches:
   - path: pihole-values.yaml
+  - path: adguard-home-values.yaml

--- a/settings/dev/cluster-settings.yaml
+++ b/settings/dev/cluster-settings.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: flux-system
   name: cluster-settings
 data:
-  EXAMPLE: value
+  ADGUARD_HOME_IP: 10.10.24.12


### PR DESCRIPTION
Set up initial Adguard Home instance, with dev. Use common cluster settings for the IP address, which is a new pattern not yet established in the cluster.
Issue #521