### PR TITLE
Disable persistence for data adguard-home (leave config)

### DIFF
--- a/network/base/adguard-home/release.yaml
+++ b/network/base/adguard-home/release.yaml
@@ -29,10 +29,6 @@ spec:
       repository: adguard/adguardhome
       tag: v0.108.0-b.3
 
-    persistence:
-      data:
-        enabled: true
-
     service:
       dns-tcp:
         annotations:


### PR DESCRIPTION
Issue #521 
Not needed, and requires extra configuration.