### PR TITLE
Exercise new docker image for RTSPtoWeb

### DIFF
--- a/home/dev/stream/rtsp-to-web.yaml
+++ b/home/dev/stream/rtsp-to-web.yaml
@@ -44,7 +44,7 @@ spec:
       - env:
         - name: TZ
           value: America/Los_Angeles
-        image: ghcr.io/allenporter/amd64-rtsp-to-web:1.0.0
+        image: ghcr.io/deepch/rtsptoweb:1.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3


### PR DESCRIPTION
Test out new official docker release for RTSPtoWeb in k8s added in
https://github.com/deepch/RTSPtoWeb/issues/91