### PR TITLE
Add InfoInhibitor null route

### DIFF
--- a/monitoring/base/kube-prometheus-stack/release.yaml
+++ b/monitoring/base/kube-prometheus-stack/release.yaml
@@ -127,6 +127,9 @@ spec:
           - match:
               alertname: Watchdog
             receiver: 'null'
+          - match:
+              alertname: InfoInhibitor
+            receiver: 'null'
         receivers:
         - name: 'null'
         - name: 'discord'


### PR DESCRIPTION
Add InfoInhibitor null route for new rule that always fires, similar to watchdog.