### PR TITLE
Upgrade hajimari to support kubernetes 1.22.X

### DIFF
--- a/home/dev/hajimari-values.yaml
+++ b/home/dev/hajimari-values.yaml
@@ -11,6 +11,9 @@ spec:
       chart: hajimari
       version: 1.2.0
   values:
+    image:
+      repository: ghcr.io/toboshii/hajimari
+      tag: v0.2.0
     ingress:
       main:
         annotations:


### PR DESCRIPTION
Upgrade hajimari to support kubernetes 1.22.X

Fixes:
```
the server could not find the requested resource (get ingresses.extensions)
```
Which was likely the source of read traffic I identified in https://github.com/allenporter/k8s-gitops/issues/574

https://github.com/toboshii/hajimari/issues/31