### PR TITLE
Add istio monitoring

### DIFF
--- a/services/base/istio/kustomization.yaml
+++ b/services/base/istio/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - namespace.yaml
   - release.yaml
   - ingress-class.yaml
+  - servicemonitor.yaml

--- a/services/base/istio/servicemonitor.yaml
+++ b/services/base/istio/servicemonitor.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: istiod
+  namespace: istio-system
+spec:
+  namespaceSelector:
+    matchNames:
+      - istio-system
+  selector:
+    matchLabels:
+      app: istiod
+  endpoints:
+    - port: http-monitoring
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: ingress
+  namespace: istio-ingress
+spec:
+  namespaceSelector:
+    matchNames:
+      - istio-ingress
+  selector:
+    matchLabels:
+      app: ingress
+  endpoints:
+    - port: status-port


### PR DESCRIPTION
Add istio monitoring with a service monitor. The istio helm chart adds prometheus scrape variables by default, which are not used by the prometheus-operator.

Future work could be to contribute a ServiceMonitor to the istio helm charts if this seems useful to share.

Issue #248