### PR TITLE
Exclude grafana resource since it fails to import

### DIFF
--- a/services/base/istio/kustomization.yaml
+++ b/services/base/istio/kustomization.yaml
@@ -6,4 +6,3 @@ resources:
   - release.yaml
   - ingress-class.yaml
   - https://raw.githubusercontent.com/istio/istio/release-1.13/samples/addons/extras/prometheus-operator.yaml
-  - https://raw.githubusercontent.com/istio/istio/release-1.13/samples/addons/grafana.yaml


### PR DESCRIPTION
var substitution failed for 'istio-services-grafana-dashboards': YAMLToJSON: yaml: line 9: did not find expected key