### PR TITLE
Copy rtsp-to-web config on startup

### DIFF
--- a/home/base/rtsp-to-web/release.yaml
+++ b/home/base/rtsp-to-web/release.yaml
@@ -41,7 +41,25 @@ spec:
               - rtsp-to-web.${DOMAIN}
     hostNetwork: true
     persistence:
-      config:
+      config-readonly:
         enabled: true
         type: configMap
         name: rtsp-to-web-config
+      config:
+        enabled: true
+        type: emptyDIr
+    initContainers:
+      - name: copy
+        image: busybox
+        command:
+          - "sh"
+          - "-c"
+          - |
+            if [ ! -f /config/config.json ]; then
+              cp /config-readonly/config.json /config/config.json
+            fi
+        volumeMounts:
+          - mountPath: /config-readonly
+            name: config-readonly
+          - mountPath: /config
+            name: config


### PR DESCRIPTION
Avoid issues with readonly /config paths.