### PR TITLE
Remove list from initcontainer

### DIFF
--- a/home/base/rtsp-to-web/release.yaml
+++ b/home/base/rtsp-to-web/release.yaml
@@ -50,17 +50,17 @@ spec:
         type: emptyDIr
     initContainers:
       copy:
-        - name: copy
-          image: busybox
-          command:
-            - "sh"
-            - "-c"
-            - |
-              if [ ! -f /config/config.json ]; then
-                cp /config-readonly/config.json /config/config.json
-              fi
-          volumeMounts:
-            - mountPath: /config-readonly
-              name: config-readonly
-            - mountPath: /config
-              name: config
+        name: copy
+        image: busybox
+        command:
+          - "sh"
+          - "-c"
+          - |
+            if [ ! -f /config/config.json ]; then
+              cp /config-readonly/config.json /config/config.json
+            fi
+        volumeMounts:
+          - mountPath: /config-readonly
+            name: config-readonly
+          - mountPath: /config
+            name: config


### PR DESCRIPTION
Resolve issue:

✗ HelmRelease reconciliation failed: Helm upgrade failed: template: rtsp-to-web/templates/common.yaml:1:3: executing "rtsp-to-web/templates/common.yaml" at <include "common.all" .>: error calling include: template: rtsp-to-web/charts/common/templates/_all.tpl:39:10: executing "common.all" at <include "common.deployment" .>: error calling include: template: rtsp-to-web/charts/common/templates/_deployment.tpl:55:10: executing "common.deployment" at <include "common.controller.pod" .>: error calling include: template: rtsp-to-web/charts/common/templates/lib/controller/_pod.tpl:50:27: executing "common.controller.pod" at <$container.name>: can't evaluate field name in type []interface {}
