### PR TITLE
Set adguard node selector on prod instances only

### DIFF
--- a/network/base/adguard-home/release.yaml
+++ b/network/base/adguard-home/release.yaml
@@ -25,9 +25,6 @@ spec:
     env:
       TZ: "America/Los_Angeles"
 
-    nodeSelector:
-      target_node: pelican
-
     service:
       dns-tcp:
         type: LoadBalancer

--- a/network/base/adguard-home/release2.yaml
+++ b/network/base/adguard-home/release2.yaml
@@ -25,9 +25,6 @@ spec:
     env:
       TZ: "America/Los_Angeles"
 
-    nodeSelector:
-      target_node: sonar
-
     service:
       dns-tcp:
         type: LoadBalancer

--- a/network/prod/adguard-home-values.yaml
+++ b/network/prod/adguard-home-values.yaml
@@ -14,3 +14,6 @@ spec:
     image:
       repository: adguard/adguardhome
       tag: v0.108.0-b.3
+
+    nodeSelector:
+      target_node: pelican  # vmm01.prod

--- a/network/prod/adguard-home2-values.yaml
+++ b/network/prod/adguard-home2-values.yaml
@@ -14,3 +14,6 @@ spec:
     image:
       repository: adguard/adguardhome
       tag: v0.108.0-b.3
+
+    nodeSelector:
+      target_node: sonar  # vmm02.prod


### PR DESCRIPTION
Set adguard node selector on prod instances only, removing from dev which has a different set of nodes.