### PR TITLE
Update calico to 3.23 and remove renovate

### DIFF
--- a/infrastructure/dev/kustomization.yaml
+++ b/infrastructure/dev/kustomization.yaml
@@ -11,4 +11,4 @@ resources:
 - ../base/rook-ceph
 - ../base/benji
 - benji-secrets.yaml
-- https://docs.projectcalico.org/archive/v3.21/manifests/calico.yaml
+- https://docs.projectcalico.org/archive/v3.23/manifests/calico.yaml

--- a/renovate.json5
+++ b/renovate.json5
@@ -27,16 +27,6 @@
       datasourceTemplate: "github-releases",
       versioningTemplate: "semver",
     },
-    {
-      description: "Calico manifest matcher",
-      "fileMatch": [".+\\.yaml$"],
-      matchStrings: [
-        "https:\\/\\/docs.projectcalico.org\\/archive\\/(?<currentValue>[\\w\\d\\.\\-_]+)\\/manifests.*",
-      ],
-      depNameTemplate: "projectcalico/calico",
-      datasourceTemplate: "github-releases",
-      versioningTemplate: "semver",
-    },
   ],
   "helm-values": {
     // Match value files in HelmReleases. This is used so that renovate include

--- a/tests/kustomize_validation_test.py
+++ b/tests/kustomize_validation_test.py
@@ -39,6 +39,7 @@ ALLOWED_API_RESOURCES = {
     ("PersistentVolume", "v1"),
     ("PersistentVolumeClaim", "v1"),
     ("PodDisruptionBudget", "policy/v1beta1"),
+    ("PodDisruptionBudget", "policy/v1"),
     ("PodMonitor", "monitoring.coreos.com/v1"),
     ("PrometheusRule", "monitoring.coreos.com/v1"),
     ("Provider", "notification.toolkit.fluxcd.io/v1beta1"),


### PR DESCRIPTION
Update calico to 3.23 and remove renovate since it doesn't match those version. The manifest version on the site has fewer version numbers anyway.