### PR TITLE
Update etcd monitoring port after kube-prometheus-stack upgrade

### DIFF
--- a/monitoring/dev/kube-prometheus-stack-values.yaml
+++ b/monitoring/dev/kube-prometheus-stack-values.yaml
@@ -50,4 +50,4 @@ spec:
     kubeEtcd:
       enabled: true
       endpoints:
-        - ${ETCD_IP}
+        - ${ETCD_IP}:2379

--- a/monitoring/dev/kube-prometheus-stack-values.yaml
+++ b/monitoring/dev/kube-prometheus-stack-values.yaml
@@ -50,4 +50,8 @@ spec:
     kubeEtcd:
       enabled: true
       endpoints:
-        - ${ETCD_IP}:2379
+        - ${ETCD_IP}
+      service:
+        enabled: true
+        port: 2379
+        targetPort: 2379


### PR DESCRIPTION
Update etcd monitoring port after kube-prometheus-stack upgrade which seems to have changed a default port. The new default does not work with an external etcd cluster.