### PR TITLE
Revert etcd monitoring ports after kube-prometheus-stack upgrade

### DIFF
--- a/monitoring/prod/kube-prometheus-stack-values.yaml
+++ b/monitoring/prod/kube-prometheus-stack-values.yaml
@@ -53,3 +53,7 @@ spec:
         - ${ETCD1_IP}
         - ${ETCD2_IP}
         - ${ETCD3_IP}
+      service:
+        enabled: true
+        port: 2379
+        targetPort: 2379


### PR DESCRIPTION
Fix merge in https://github.com/allenporter/k8s-gitops/pull/782