### PR TITLE
Add home assistant prometheus rule for automations

### DIFF
--- a/home/prod/kustomization.yaml
+++ b/home/prod/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - ../base/mosquitto
   - ../base/hajimari
   - ../base/rtsp-to-web
+  - prometheus-rules.yaml
 patches:
   - path: home-assistant-values.yaml
   - path: teslamate-values.yaml

--- a/home/prod/prometheus-rules.yaml
+++ b/home/prod/prometheus-rules.yaml
@@ -7,6 +7,7 @@ metadata:
     prometheus: nginx
     role: alert-rules
   name: home-assistant-prometheus-rules
+  namespace: home-assistant
 spec:
   groups:
   - name: HomeAssistantPrometheusRules

--- a/home/prod/prometheus-rules.yaml
+++ b/home/prod/prometheus-rules.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  creationTimestamp: null
+  labels:
+    prometheus: nginx
+    role: alert-rules
+  name: home-assistant-prometheus-rules
+spec:
+  groups:
+  - name: HomeAssistantPrometheusRules
+    rules:
+    - alert: LightAutomationUnavailable
+      expr: hass_entity_available{entity="automation.driveway_light_calendar"} != 1
+      for: 30m
+      labels:
+        severity: critical
+      annotations:
+        description: Home Assistant Light Automation is unavailable
+        summary: Automations unavailable, check home assistant status

--- a/scripts/pvc-recover.yaml
+++ b/scripts/pvc-recover.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: mc02-mnt-pod
+  namespace: minecraft
+spec:
+  volumes:
+    - name: task-pv-storage
+      persistentVolumeClaim:
+        claimName: minecraft-02-minecraft-datadir
+  containers:
+    - name: task-pv-container
+      image: alpine
+      volumeMounts:
+        - mountPath: "/data"
+          name: task-pv-storage
+      command: ["/bin/sh"]
+      args: ["-c", "sleep 500000"]


### PR DESCRIPTION
Add home assistant prometheus rules. This will alert on an automation being available as a proxy for the system being alive (e.g. if recorder fails, none of the automations load). A healthy automation is a reasonable proxy for overall health.  The automation chosen is arbitrary.

Issue #51