### PR TITLE
Add an initial dev HelmRelease for nextcloud 

### DIFF
--- a/home/base/nextcloud/kustomization.yaml
+++ b/home/base/nextcloud/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: nextcloud
+resources:
+  - namespace.yaml
+  - release.yaml

--- a/home/base/nextcloud/namespace.yaml
+++ b/home/base/nextcloud/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nextcloud

--- a/home/base/nextcloud/release.yaml
+++ b/home/base/nextcloud/release.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: nextcloud
+  namespace: nextcloud
+spec:
+  releaseName: nextcloud
+  chart:
+    spec:
+      chart: nextcloud
+      sourceRef:
+        kind: HelmRepository
+        name: nextcloud
+        namespace: flux-system
+  interval: 5m
+  install:
+    remediation:
+      retries: 3
+  # https://github.com/nextcloud/helm/blob/master/charts/nextcloud/values.yaml
+  values:
+    env:
+      TZ: America/Los_Angeles
+    ingress:
+      enabled: true
+      annotations:
+        kubernetes.io/ingress.class: haproxy
+        haproxy.org/forwarded-for: "true"
+        cert-manager.io/cluster-issuer: letsencrypt
+        external-dns.alpha.kubernetes.io/hostname: nextcloud.${DOMAIN}.
+        external-dns.alpha.kubernetes.io/target: prx02.${DOMAIN}.
+        hajimari.io/icon: cloud
+        hajimari.io/appName: Nextcloud
+      tls:
+        - secretName: nextcloud-tls
+          hosts:
+            - nextcloud.${DOMAIN}
+    nextcloud:
+      host: ${NEXTCLOUD_HOST}
+      username: ${NEXTCLOUD_USERNAME}
+      password: ${NEXTCLOUD_PASSWORD}

--- a/home/dev/kustomization.yaml
+++ b/home/dev/kustomization.yaml
@@ -5,7 +5,9 @@ resources:
   - ../base/home-assistant
   - ../base/hajimari
   - ../base/rtsp-to-web
+  - ../base/nextcloud
 patches:
   - path: home-assistant-values.yaml
   - path: hajimari-values.yaml
   - path: rtsp-to-web-values.yaml
+  - path: nextcloud-values.yaml

--- a/home/dev/nextcloud-values.yaml
+++ b/home/dev/nextcloud-values.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: nextcloud
+  namespace: nextcloud
+spec:
+  chart:
+    spec:
+      # renovate
+      chart: nextcloud
+      version: 3.3.6
+  values:

--- a/infrastructure/base/sources/kustomization.yaml
+++ b/infrastructure/base/sources/kustomization.yaml
@@ -20,3 +20,4 @@ resources:
   - benji-k8s.yaml
   - hajimari.yaml
   - istio.yaml
+  - nextcloud.yaml

--- a/infrastructure/base/sources/nextcloud.yaml
+++ b/infrastructure/base/sources/nextcloud.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: nextcloud
+  namespace: flux-system
+spec:
+  interval: 30m
+  url: https://nextcloud.github.io/helm/

--- a/settings/dev/cluster-secrets.yaml
+++ b/settings/dev/cluster-secrets.yaml
@@ -5,6 +5,9 @@ data:
     HOME_ASSISTANT_MARIADB_USER_PWD: ENC[AES256_GCM,data:pXSff7zzR1bQLym08JUxFQ==,iv:ZyDAryE8xFlmvMIwVdLzFAnuW1rX8uC+lX0BjXOtwF8=,tag:cUg4BLr5sioyjrknsPbgDQ==,type:str]
     HOME_ASSISTANT_MARIADB_ROOT_PWD: ENC[AES256_GCM,data:zN2MERNcUbQjHX6vpHOaBw==,iv:MT0dRGiBlryiNy7qwyrUdQ6Ua8c99+nVckEdWjY2Q7U=,tag:4+dRZBvjO+XiP7JtMq8swA==,type:str]
     BENJI_POSTGRESQL_PWD: ENC[AES256_GCM,data:FLm2F5tt6pVsR87+kWPatcWdAeg=,iv:X4aujmeaSDEWPj2TQL4wuebzukUErf3yWTMweR3nBL0=,tag:KfOgka45Ax//L9FmzegaCQ==,type:str]
+    NEXTCLOUD_HOST: ENC[AES256_GCM,data:Gy+ysc8qViERB7qnGgumToBaLlQ/g6rKtYiiFv1K3trqDJn80F8HrA==,iv:3iKFdmcLBKOXQP0Ej9pw7zpStetAdI/ypYJhoodlgbY=,tag:6sf2dVOKuAwTizJN/Q9PeA==,type:str]
+    NEXTCLOUD_USERNAME: ENC[AES256_GCM,data:FYzBZ1T4D60=,iv:5ONpEff9VSyFUDpa1H6hvkYmLfrneX7+Kh3QxaMbgwY=,tag:rFye/6GiEwXl5edxZch4sg==,type:str]
+    NEXTCLOUD_PASSWORD: ENC[AES256_GCM,data:Ik51Xt5QABGQWtkstMFUow==,iv:G8lpaaKOH8pWjEojDq8wQKLMKfwdA1NFW++vb1OsjrU=,tag:qMOCijOd3iGDF+PUym87Gg==,type:str]
 kind: Secret
 metadata:
     creationTimestamp: null
@@ -16,8 +19,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2022-06-05T15:03:07Z"
-    mac: ENC[AES256_GCM,data:HwCnmE0ifhABi7q9jnpQgReBDCTfE1tRuyH4WV/cSY5yaKWdvp9s41d2K8Jokze2EnzdOcwyHqDYPXCtEQeOapRZ4LMn/4g7cB4AuKa0fXg/M1PkCy7GA9Cd/eoYriGBEl8iiT/VLVeT3SP2jMkOpmf/Ee29ZRiYyKiibpdmeww=,iv:4Rf4fyZzD58i4mVCytS+fN/IcOoucwxTExI7p3saMLY=,tag:wJX+8M4y731r4axcVZOXIg==,type:str]
+    lastmodified: "2022-12-28T18:04:20Z"
+    mac: ENC[AES256_GCM,data:8tJvg6y7vmD+brCnh8r+FXLHaAQEkJNxrqao3xtGjClEe31NkRNZE23yPg4iogaxldoYzB0SqZ78zpP2/3EXNNMIt1TW0k8UEzPeem8nMwDNL26snn1UJoRd4YdnLS02Nq1QsP2Q+bXRf+FXxpkUN6Nct6U2mJhrquuvKu3c1ho=,iv:PiiqloU9AN2AxzijAKa2zyJZULoCLBMcDDtG6cAybsI=,tag:+TGW7paLoVOjbTjcEGOQ+w==,type:str]
     pgp:
         - created_at: "2021-08-27T23:31:45Z"
           enc: |


### PR DESCRIPTION
The purpose is to test out caldav with python-caldav and Home Assistant. May or may not succeed, and be reverted.