### PR TITLE
Upgrade dev benji to new helm chart

### DIFF
--- a/infrastructure/dev/benji-values.yaml
+++ b/infrastructure/dev/benji-values.yaml
@@ -8,8 +8,13 @@ spec:
   releaseName: benji
   chart:
     spec:
-      chart: ./charts/benji-k8s
-      version: 1.0.0
+      # renovate:
+      chart: benji
+      sourceRef:
+        kind: HelmRepository
+        name: benji
+        namespace: flux-system
+      version: 1.1.0
   values:
     ingress:
       annotations:


### PR DESCRIPTION
Upgrade dev benji to new helm chart which moves to a `HelmRepository` away from referencing git.
Issue #853 