### PR TITLE
Upgrade prod benji chart

### DIFF
--- a/infrastructure/base/benji/release.yaml
+++ b/infrastructure/base/benji/release.yaml
@@ -8,10 +8,10 @@ spec:
   releaseName: benji
   chart:
     spec:
-      chart: ./charts/benji-k8s
+      chart: benji
       sourceRef:
-        kind: GitRepository
-        name: benji-k8s
+        kind: HelmRepository
+        name: benji
         namespace: flux-system
   interval: 1h0m0s
   install:

--- a/infrastructure/dev/benji-values.yaml
+++ b/infrastructure/dev/benji-values.yaml
@@ -8,12 +8,7 @@ spec:
   releaseName: benji
   chart:
     spec:
-      # renovate:
       chart: benji
-      sourceRef:
-        kind: HelmRepository
-        name: benji
-        namespace: flux-system
       version: 1.1.0
   values:
     ingress:

--- a/infrastructure/prod/benji-values.yaml
+++ b/infrastructure/prod/benji-values.yaml
@@ -8,8 +8,8 @@ spec:
   releaseName: benji
   chart:
     spec:
-      chart: ./charts/benji-k8s
-      version: 1.0.0
+      chart: benji
+      version: 1.1.0
   values:
     ingress:
       annotations:


### PR DESCRIPTION
Upgrade prod benji chart, following pattern that already exists in dev. Move the dev overlay logic down to the base template to be shared with prod.

Removes the `# renovate` tag which will be added by the cron job (I previously forgot how it worked)

Issue #853 