### PR TITLE
Disable wait when upgrading minecraft servers

### DIFF
--- a/games/prod/minecraft-05-values.yaml
+++ b/games/prod/minecraft-05-values.yaml
@@ -19,6 +19,8 @@ spec:
   install:
     remediation:
       retries: 3
+  upgrade:
+    disableWait: true
   test:
     # Fix problem where helm fails to uninstall
     enable: false

--- a/games/prod/minecraft-06-values.yaml
+++ b/games/prod/minecraft-06-values.yaml
@@ -19,6 +19,8 @@ spec:
   install:
     remediation:
       retries: 3
+  upgrade:
+    disableWait: true
   test:
     # Fix problem where helm fails to uninstall
     enable: false

--- a/games/prod/minecraft-07-values.yaml
+++ b/games/prod/minecraft-07-values.yaml
@@ -19,6 +19,8 @@ spec:
   install:
     remediation:
       retries: 3
+  upgrade:
+    disableWait: true
   test:
     # Fix problem where helm fails to uninstall
     enable: false

--- a/games/prod/minecraft-08-values.yaml
+++ b/games/prod/minecraft-08-values.yaml
@@ -19,6 +19,8 @@ spec:
   install:
     remediation:
       retries: 3
+  upgrade:
+    disableWait: true
   test:
     # Fix problem where helm fails to uninstall
     enable: false

--- a/games/prod/minecraft-119-values.yaml
+++ b/games/prod/minecraft-119-values.yaml
@@ -19,6 +19,8 @@ spec:
   install:
     remediation:
       retries: 3
+  upgrade:
+    disableWait: true
   test:
     # Fix problem where helm fails to uninstall
     enable: false


### PR DESCRIPTION
Disabling wait to avoid `timed out waiting for the condition` when upgrading minecraft chart:

```
minecraft-05                 213d   False   upgrade retries exhausted
```

```
20      	Sun Jan 29 18:28:04 2023	failed         	minecraft-4.5.0	SeeValues  	Upgrade "minecraft-05" failed: timed out waiting for the condition
```