### PR TITLE
Pipe HelmRelease output directly to kyverno

### DIFF
--- a/monitoring/base/kubernetes-dashboard/release.yaml
+++ b/monitoring/base/kubernetes-dashboard/release.yaml
@@ -28,7 +28,6 @@ spec:
     ingress:
       enabled: true
       annotations:
-        kubernetes.io/ingress.class: haproxy
         cert-manager.io/cluster-issuer: letsencrypt
         hajimari.io/icon: "kubernetes"
         hajimari.io/appName: "Kubernetes Dashboard"

--- a/scripts/manifest/cmd.py
+++ b/scripts/manifest/cmd.py
@@ -19,6 +19,7 @@ async def run_piped_commands(cmds: list[list[str]]) -> str:
     out = None
     for cmd in cmds:
         cmd_text = " ".join([shlex.quote(arg) for arg in cmd])
+        _LOGGER.debug("Running command: %s", cmd_text)
         proc = await asyncio.create_subprocess_shell(
             cmd_text,
             stdin=subprocess.PIPE,

--- a/scripts/manifest/manifest.py
+++ b/scripts/manifest/manifest.py
@@ -51,6 +51,11 @@ class HelmRelease:
             raise ValueError(f"Invalid {cls} missing sourceRef fields: {doc}")
         return cls(name, namespace, source_ref["name"], source_ref["namespace"])
 
+    @property
+    def id(self) -> str:
+        """Identifier for the HelmRelease in tests."""
+        return f"{self.namespace}-{self.name}"
+
 
 @dataclass
 class HelmRepository:
@@ -75,6 +80,11 @@ class HelmRepository:
             raise ValueError(f"Invalid {cls} missing spec.url: {doc}")
         return cls(name, namespace, url)
 
+    @property
+    def id(self) -> str:
+        """Identifier for the HelmRepository in tests."""
+        return f"{self.namespace}-{self.name}"
+
 
 @dataclass
 class Kustomization:
@@ -89,6 +99,11 @@ class Kustomization:
     def full_path(self) -> Path:
         """Return the full cluster path for this object."""
         return repo_root() / self.path
+
+    @property
+    def id(self) -> str:
+        """Identifier for the Kustomization in tests"""
+        return f"{self.path}"
 
 
 @dataclass
@@ -118,6 +133,11 @@ class Cluster:
             "generated": now.isoformat(),
             "repositories": repos,
         }
+
+    @property
+    def id(self) -> str:
+        """Identifier for the Cluster in tests."""
+        return f"{self.path}"
 
 
 class Manifest(BaseModel):


### PR DESCRIPTION
This changes the test behavior to create a single test per `HelmRelease` rather than per `Kustomziation`. This is ok because each command to run `kustomize build | kustomize grep` is very fast and only the helm `template` command itself is really the bottleneck.

This fixes an issue trying to run yaml back and forth through python since it may corrupt / truncate, which was the cause of missing `helmrelease-dashboard` policy errors.

Issue #919 