### PR TITLE
Run kyverno test against Ingress policies

### DIFF
--- a/infrastructure/base/policies/ingress.yaml
+++ b/infrastructure/base/policies/ingress.yaml
@@ -25,7 +25,8 @@ spec:
       pattern:
         metadata:
           annotations:
-            X(kubernetes.io/ingress.class): "null"
+            #X(kubernetes.io/ingress.class): "null"
+            kubernetes.io/ingress.class: "foo"
   - name: validate-ingress-class
     match:
       resources:

--- a/infrastructure/base/policies/ingress.yaml
+++ b/infrastructure/base/policies/ingress.yaml
@@ -24,9 +24,8 @@ spec:
       message: "Found kubernetes.io/ingress.class annotation"
       pattern:
         metadata:
-          annotations:
-            #X(kubernetes.io/ingress.class): "null"
-            kubernetes.io/ingress.class: "foo"
+          =(annotations):
+            X(kubernetes.io/ingress.class): "null"
   - name: validate-ingress-class
     match:
       resources:

--- a/tests/policies/ingress/ingress.yaml
+++ b/tests/policies/ingress/ingress.yaml
@@ -1,0 +1,92 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: example-default-ingressclass
+  namespace: ns
+spec:
+  rules:
+  - host: example.hsot
+    http:
+      paths:
+      - backend:
+          service:
+            name: example
+            port:
+              number: 8083
+        path: /
+        pathType: Prefix
+  tls:
+  - hosts:
+    - example-host
+    secretName: example-tls
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: example-ingressclass
+  namespace: ns
+spec:
+  ingressClass: haproxy
+  rules:
+  - host: example.hsot
+    http:
+      paths:
+      - backend:
+          service:
+            name: example
+            port:
+              number: 8083
+        path: /
+        pathType: Prefix
+  tls:
+  - hosts:
+    - example-host
+    secretName: example-tls
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: example-with-annotation
+  namespace: ns
+  annotations:
+    kubernetes.io/ingress.class: haproxy
+spec:
+  rules:
+  - host: example.hsot
+    http:
+      paths:
+      - backend:
+          service:
+            name: example
+            port:
+              number: 8083
+        path: /
+        pathType: Prefix
+  tls:
+  - hosts:
+    - example-host
+    secretName: example-tls
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: example-unknown-ingressclass
+  namespace: ns
+spec:
+  ingressClass: foo
+  rules:
+  - host: example.hsot
+    http:
+      paths:
+      - backend:
+          service:
+            name: example
+            port:
+              number: 8083
+        path: /
+        pathType: Prefix
+  tls:
+  - hosts:
+    - example-host
+    secretName: example-tls

--- a/tests/policies/ingress/kyverno-test.yaml
+++ b/tests/policies/ingress/kyverno-test.yaml
@@ -1,0 +1,37 @@
+---
+name: ingress-classes
+resources:
+- ingress.yaml
+policies:
+- ../../../infrastructure/base/policies/ingress.yaml
+results:
+
+# Require a valid IngressClass when present
+- policy: restrict-ingress-classes
+  rule: validate-ingress-class
+  kind: Ingress
+  result: pass
+  resources:
+  - example-ingressclass
+  - example-default-ingressclass
+- policy: restrict-ingress-classes
+  rule: validate-ingress-class
+  kind: Ingress
+  result: fail
+  resources:
+  - example-unknown-ingressclass
+
+# Stop using deprecated annotations
+- policy: restrict-ingress-classes
+  rule: forbid-ingress-annotations
+  kind: Ingress
+  result: pass
+  resources:
+  - example-ingressclass
+  - example-default-ingressclass
+- policy: restrict-ingress-classes
+  rule: forbid-ingress-annotations
+  kind: Ingress
+  result: fail
+  resources:
+  - example-with-annotation

--- a/tests/test_kyverno.py
+++ b/tests/test_kyverno.py
@@ -1,0 +1,27 @@
+"""Tests that run `kyverno test`.
+
+Tests here are used to test the policies themselves, and not actually applying
+policies to cluster resources. That is done in other tests for the specific
+resources.
+
+See https://kyverno.io/docs/kyverno-cli/#test for details on how to write
+policy tests.
+
+See `infrastructure/base/policies/` for the actual policies.
+"""
+
+from scripts.manifest import cmd
+
+
+POLICY_TEST_DIR = "tests/policies"
+
+
+async def test_policies() -> None:
+    """Run tests against the policies themselves."""
+    await cmd.run_command(
+        [
+            "kyverno",
+            "test",
+            POLICY_TEST_DIR,
+        ],
+    )


### PR DESCRIPTION
Run kyverno test against policies. Add some example resources with pass and fail cases to run against the policy.

This runs from python only because we already have an existing test harness, but could be done from CI or locally directly w/o python.