### PR TITLE
Use kyverno policies to allowlist api and kind versions

### DIFF
--- a/.github/workflows/diff-hr-on-pr.yaml
+++ b/.github/workflows/diff-hr-on-pr.yaml
@@ -76,6 +76,7 @@ jobs:
           resources_live=$(echo "$hr_live_values" | \
             helm template "$hr_live_chart" \
             live/"$hr_live_chart" \
+            --skip-crds \
             --version "$hr_live_version" -f -)
           echo "$resources_live"
           echo "#####################################################"
@@ -83,6 +84,7 @@ jobs:
           resources_pr=$(echo "$hr_pr_values" | \
             helm template "$hr_pr_chart" \
             pr/"$hr_pr_chart" \
+            --skip-crds \
             --version "$hr_pr_version" -f -)
           echo "$resources_pr"
           echo "#####################################################"

--- a/infrastructure/base/benji/backup-postgres-job.yaml
+++ b/infrastructure/base/benji/backup-postgres-job.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: benji-backup-postgres

--- a/infrastructure/base/policies/kustomization.yaml
+++ b/infrastructure/base/policies/kustomization.yaml
@@ -4,3 +4,5 @@ kind: Kustomization
 namespace: kyverno
 resources:
   - ingress.yaml
+  - resources.yaml
+  - https://raw.githubusercontent.com/kyverno/policies/main/best-practices/check_deprecated_apis/check_deprecated_apis.yaml

--- a/infrastructure/base/policies/resources.yaml
+++ b/infrastructure/base/policies/resources.yaml
@@ -1,0 +1,79 @@
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: limit-resources
+  annotations:
+    policies.kyverno.io/title: Allowed Resources
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/description: >-
+      Create an allow list of allowed resources. This can help with version
+      upgrades or deprecations, or more generally keeping the state of the
+      cluster in check.
+spec:
+  validationFailureAction: audit
+  background: false
+  rules:
+  - name: allowlist
+    match:
+      any:
+      - resources:
+          kinds:
+          - "*"
+    exclude:
+      all:
+      - resources:
+          kinds:
+    preconditions:
+      all:
+      - key: "{{ request.operation || 'BACKGROUND' }}"
+        operator: NotEquals
+        value: DELETE
+      - key:
+        - "{{request.object.apiVersion}}"
+        operator: AllNotIn
+        value:
+        - v1
+        - apps/v1
+        - batch/v1
+        - monitoring.grafana.com/v1alpha1
+        - monitoring.coreos.com/v1
+      - key:
+        - "{{request.object.apiVersion}} {{ request.object.kind }}"
+        operator: AllNotIn
+        value:
+        # Flux & Helm
+        - helm.toolkit.fluxcd.io/v2beta1 HelmRelease
+        - notification.toolkit.fluxcd.io/v1beta2 Alert
+        - notification.toolkit.fluxcd.io/v1beta2 Provider
+        - source.toolkit.fluxcd.io/v1beta2 GitRepository
+        - source.toolkit.fluxcd.io/v1beta2 HelmRepository
+        # Ceph
+        - ceph.rook.io/v1 CephCluster
+        - cert-manager.io/v1 ClusterIssuer
+        # Networking & Services
+        - kyverno.io/v1 ClusterPolicy
+        - networking.istio.io/v1alpha3 EnvoyFilter
+        - metallb.io/v1beta1 IPAddressPool
+        - metallb.io/v1beta1 L2Advertisement
+        # k8s
+        - admissionregistration.k8s.io/v1 MutatingWebhookConfiguration
+        - admissionregistration.k8s.io/v1 ValidatingWebhookConfiguration
+        - autoscaling/v2 HorizontalPodAutoscaler
+        - apiextensions.k8s.io/v1 CustomResourceDefinition
+        - networking.k8s.io/v1 Ingress
+        - networking.k8s.io/v1 IngressClass
+        - networking.k8s.io/v1 NetworkPolicy
+        - policy/v1beta1 PodDisruptionBudget
+        - policy/v1beta1 PodSecurityPolicy
+        - policy/v1 PodDisruptionBudget
+        - rbac.authorization.k8s.io/v1 ClusterRole
+        - rbac.authorization.k8s.io/v1 ClusterRoleBinding
+        - rbac.authorization.k8s.io/v1 Role
+        - rbac.authorization.k8s.io/v1 RoleBinding
+        - storage.k8s.io/v1 StorageClass
+        - snapshot.storage.k8s.io/v1 VolumeSnapshot
+        - snapshot.storage.k8s.io/v1 VolumeSnapshotClass
+    validate:
+      message: "{{ request.object.apiVersion }}/{{ request.object.kind }} is not in allowlist"
+      deny: {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import pytest
 import datetime
-import git
 import os
 from pathlib import Path
 import subprocess
@@ -25,55 +24,13 @@ logging.basicConfig(format=_LOG_FMT)
 _LOGGER = logging.getLogger(__name__)
 
 
+# Note: We should really only build policies included in the kustomize build, similar
+# to how we manage helm releases.
+POLICY_DIR = "infrastructure/base/policies"
+
+
 HELMREPO_KINDS = {("HelmRepository", "source.toolkit.fluxcd.io/v1beta2")}
 HELMRELEASE_KINDS = {("HelmRelease", "helm.toolkit.fluxcd.io/v2beta1")}
-
-# Allow all API resources with these versions
-ALLOWED_API_VERSIONS = {
-    "v1",
-    "apps/v1",
-    "batch/v1",
-    "monitoring.grafana.com/v1alpha1",
-    "monitoring.coreos.com/v1",
-}
-
-# Allow specific API resources with specific versions
-ALLOWED_API_RESOURCES = (
-    HELMREPO_KINDS
-    | HELMRELEASE_KINDS
-    | {
-        ("Alert", "notification.toolkit.fluxcd.io/v1beta2"),
-        ("CephCluster", "ceph.rook.io/v1"),
-        ("ClusterIssuer", "cert-manager.io/v1"),
-        ("ClusterRole", "rbac.authorization.k8s.io/v1"),
-        ("ClusterRoleBinding", "rbac.authorization.k8s.io/v1"),
-        ("ClusterPolicy", "kyverno.io/v1"),
-        ("CustomResourceDefinition", "apiextensions.k8s.io/v1"),
-        ("CronJob", "batch/v1beta1"),
-        ("EnvoyFilter", "networking.istio.io/v1alpha3"),
-        ("GitRepository", "source.toolkit.fluxcd.io/v1beta2"),
-        ("HorizontalPodAutoscaler", "autoscaling/v2"),
-        ("Ingress", "networking.k8s.io/v1"),
-        ("IngressClass", "networking.k8s.io/v1"),
-        ("IPAddressPool", "metallb.io/v1beta1"),
-        ("L2Advertisement", "metallb.io/v1beta1"),
-        ("MutatingWebhookConfiguration", "admissionregistration.k8s.io/v1"),
-        ("PodDisruptionBudget", "policy/v1beta1"),
-        ("PodDisruptionBudget", "policy/v1"),
-        ("PodMonitor", "monitoring.coreos.com/v1"),
-        ("PodSecurityPolicy", "policy/v1beta1"),
-        ("NetworkPolicy", "networking.k8s.io/v1"),
-        ("PrometheusRule", "monitoring.coreos.com/v1"),
-        ("Provider", "notification.toolkit.fluxcd.io/v1beta2"),
-        ("Role", "rbac.authorization.k8s.io/v1"),
-        ("RoleBinding", "rbac.authorization.k8s.io/v1"),
-        ("ServiceMonitor", "monitoring.coreos.com/v1"),
-        ("StorageClass", "storage.k8s.io/v1"),
-        ("VolumeSnapshot", "snapshot.storage.k8s.io/v1"),
-        ("VolumeSnapshotClass", "snapshot.storage.k8s.io/v1"),
-        ("ValidatingWebhookConfiguration", "admissionregistration.k8s.io/v1"),
-    }
-)
 
 
 @pytest.fixture(scope="module")
@@ -81,26 +38,6 @@ def event_loop(request):
     loop = asyncio.get_event_loop_policy().new_event_loop()
     yield loop
     loop.close()
-
-
-def kind_filter(kinds: set[tuple[str, str]]):
-    """Return a yaml doc filter for specified resource type and version."""
-
-    def func(doc):
-        return (doc.get("kind"), doc.get("apiVersion")) in kinds
-
-    return func
-
-
-async def kustomize_build(filename: Path) -> str:
-    """Return kustomize build and return the string contents."""
-    return await cmd.run_command(["kustomize", "build", str(filename)])
-
-
-async def kustomize_build_resources(filename: Path) -> list[dict[str, Any]]:
-    """Run kustomize build and return the parsed objects."""
-    doc_contents = await kustomize_build(filename)
-    return list(yaml.safe_load_all(doc_contents))
 
 
 @pytest.fixture(autouse=True, scope="session")
@@ -117,28 +54,7 @@ def yaml_hack() -> None:
     )
 
 
-def is_k8s(resource: dict[str, Any]) -> bool:
-    """Return true if the object is a kubernetes resource."""
-    assert resource
-    return "kind" in resource and "apiVersion" in resource
-
-
-def kind(resource: dict[str, Any]) -> tuple[str, str]:
-    """Function to return the kind of a resource."""
-    return (resource["kind"], resource["apiVersion"])
-
-
-def is_resource_allowed(resource: dict[str, Any]) -> bool:
-    """Validate the resource is allowed."""
-    key = kind(resource)
-    return key in ALLOWED_API_RESOURCES or key[1] in ALLOWED_API_VERSIONS
-
-
-def is_kind_allowed(key: tuple[str, str]) -> bool:
-    """Validate the resource is allowed."""
-    return key in ALLOWED_API_RESOURCES or key[1] in ALLOWED_API_VERSIONS
-
-
+# TODO: Move to kyverno
 ALLOWED_INGRESS_ANNOTATIONS = {
     "cert-manager.io/cluster-issuer",
     "external-dns.alpha.kubernetes.io/hostname",
@@ -151,42 +67,3 @@ ALLOWED_INGRESS_ANNOTATIONS = {
     "nginx.ingress.kubernetes.io/backend-protocol",
     "service.alpha.kubernetes.io/app-protocols",
 }
-
-
-def validate_ingress(ingress: dict[str, Any]) -> bool:
-    """Validate that the ingress is valid."""
-    keys = ingress["metadata"].get("annotations", {}).keys()
-    return all([key for key in keys if key not in ALLOWED_INGRESS_ANNOTATIONS])
-
-
-VALIDATION_HOOKS: dict[Callable[[dict[str, Any]], None]] = {
-    "Ingress": [validate_ingress]
-}
-
-
-async def validate_resources(resources: dict[str, Any]) -> bool:
-    """Test method that asserts that resources are valid."""
-    k8s_resources = [
-        resource for resource in resources if resource is not None and is_k8s(resource)
-    ]
-
-    # Must have at least one valid resource
-    if not any(k8s_resources):
-        _LOGGER.error("Did not have at least one valid resource")
-        return False
-
-    kinds = set(map(kind, k8s_resources))
-
-    not_found = [kind for kind in kinds if not is_kind_allowed(kind)]
-    if not_found:
-        _LOGGER.error("Resource version not in allow list: %s", not_found)
-        return False
-
-    for k8s_resource in k8s_resources:
-        key = kind(k8s_resource)[0]
-        for hook in VALIDATION_HOOKS.get(key, []):
-            if not hook(k8s_resource):
-                _LOGGER.debug("Valid hook for %s", key)
-                return False
-
-    return True

--- a/tests/policies/ingress/kyverno-test.yaml
+++ b/tests/policies/ingress/kyverno-test.yaml
@@ -1,5 +1,5 @@
 ---
-name: ingress-classes
+name: ingress
 resources:
 - ingress.yaml
 policies:
@@ -20,7 +20,6 @@ results:
   result: fail
   resources:
   - example-unknown-ingressclass
-
 # Stop using deprecated annotations
 - policy: restrict-ingress-classes
   rule: forbid-ingress-annotations

--- a/tests/policies/resources/kyverno-test.yaml
+++ b/tests/policies/resources/kyverno-test.yaml
@@ -1,0 +1,37 @@
+---
+name: resources
+resources:
+- resources.yaml
+policies:
+- ../../../infrastructure/base/policies/resources.yaml
+results:
+
+# Example in allow list
+- policy: limit-resources
+  rule: allowlist
+  kind: ClusterIssuer
+  result: skip
+  resources:
+  - cluster-issuer
+
+- policy: limit-resources
+  rule: allowlist
+  kind: CronJob
+  result: skip
+  resources:
+  - cron-job
+
+# Examples not in allow list
+- policy: limit-resources
+  rule: allowlist
+  kind: ClusterIssuer
+  result: fail
+  resources:
+  - cluster-issuer-wrong-version
+
+- policy: limit-resources
+  rule: allowlist
+  kind: Unknown
+  result: fail
+  resources:
+  - unknown-resource

--- a/tests/policies/resources/resources.yaml
+++ b/tests/policies/resources/resources.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: cluster-issuer
+spec:
+  example: foo
+
+---
+apiVersion: cert-manager.io/v1beta1
+kind: ClusterIssuer
+metadata:
+  name: cluster-issuer-wrong-version
+spec:
+  example: foo
+
+---
+apiVersion: cert-manager.io/v1
+kind: Unknown
+metadata:
+  name: unknown-resource
+spec:
+  example: foo
+
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cron-job
+spec:
+  example: foo

--- a/tests/test_helm_release.py
+++ b/tests/test_helm_release.py
@@ -18,12 +18,7 @@ import yaml
 from scripts.manifest import manifest, cmd
 
 from .conftest import (
-    kustomize_build_resources,
-    kind_filter,
-    kind,
-    is_kind_allowed,
-    HELMRELEASE_KINDS,
-    validate_resources,
+    POLICY_DIR,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -31,7 +26,6 @@ _LOGGER = logging.getLogger(__name__)
 KUSTOMIZE_BIN = "kustomize"
 HELM_RELEASE_KIND = "HelmRelease"
 HELM_RELEASE_VERSIONS = {"helm.toolkit.fluxcd.io/v2beta1"}
-POLICY_DIR = "infrastructure/base/policies"
 
 
 MANIFEST = manifest.manifest()
@@ -209,9 +203,3 @@ async def test_validate_helm_release(
             ],
         ]
     )
-
-    # Run helm template command and apply local tests
-    # TODO: Remove this and replace with full kyverno policies
-    result = await cmd.run_command(args)
-    docs = list(yaml.safe_load_all(result))
-    assert await validate_resources(docs), "Invalid HelmRelease"


### PR DESCRIPTION
Update kyverno policies to have an allowlist of resources, removing the python version of the check.

Also skip crds in hr diff to avoid too large output on PR. For example, recent rook-ceph upgrade makes diff too large.

Issue #919 