### PR TITLE
Don't test HelmRelease for kube-prometheus-stack

### DIFF
--- a/monitoring/base/kube-prometheus-stack/release.yaml
+++ b/monitoring/base/kube-prometheus-stack/release.yaml
@@ -23,7 +23,7 @@ spec:
   upgrade:
     crds: CreateReplace
   test:
-    enable: true
+    enable: false
   # Default values
   # https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml
   values:


### PR DESCRIPTION
Don't test HelmRelease for kube-prometheus-stack to fix a flaky HelmRelease which is currently stuck