### PR TITLE
Update ingress naming for weave-gitops

### DIFF
--- a/monitoring/base/weave-gitops/release.yaml
+++ b/monitoring/base/weave-gitops/release.yaml
@@ -27,17 +27,17 @@ spec:
     ingress:
       enabled: true
       annotations:
-        cert-manager.io/cluster-issuer: weave-works
-        external-dns.alpha.kubernetes.io/hostname: weave-works.${DOMAIN}.
+        cert-manager.io/cluster-issuer: letsencrypt
+        external-dns.alpha.kubernetes.io/hostname: weave-gitops.${DOMAIN}.
         external-dns.alpha.kubernetes.io/target: prx02.${DOMAIN}.
       hosts:
-        - host: weave-works.${DOMAIN}
+        - host: weave-gitops.${DOMAIN}
           paths:
             - path: /
               pathType: Prefix
       tls:
-        - secretName: weave-works-tls
+        - secretName: weave-gitops-tls
           hosts:
-            - weave-works.${DOMAIN}
+            - weave-gitops.${DOMAIN}
     metrics:
       enabled: true


### PR DESCRIPTION
Update ingress naming for weave-gitops to match the best practice. Fix incorrect letsencrypt issuer.