### PR TITLE
Add kyverno policy to verify certmanager annotations

### DIFF
--- a/clusters/manifest.yaml
+++ b/clusters/manifest.yaml
@@ -172,6 +172,8 @@ clusters:
       namespace: kyverno
     - name: require-ingress-https
       namespace: kyverno
+    - name: restrict-cluster-issuer
+      namespace: kyverno
     - name: restrict-ingress-classes
       namespace: kyverno
   - name: monitoring

--- a/infrastructure/base/policies/ingress.yaml
+++ b/infrastructure/base/policies/ingress.yaml
@@ -76,3 +76,31 @@ spec:
           - key: tls
             operator: AnyNotIn
             value: "{{ request.object.spec.keys(@) }}"
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-cluster-issuer
+  annotations:
+    policies.kyverno.io/title: Restrict Ingress Cluster Issuers to allowed set
+    policies.kyverno.io/category: Sample
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Ingress
+    policies.kyverno.io/description: >-
+      Ingress annotations for cert-manager cluster issuer may only appoint to the allowed
+      set.
+spec:
+  validationFailureAction: audit
+  background: true
+  rules:
+  - name: validate-cluster-issuer
+    match:
+      resources:
+        kinds:
+        - Ingress
+    validate:
+      message: "You must have a valid cert-manager.io/cluster-issuer annotation"
+      pattern:
+        metadata:
+          annotations:
+            cert-manager.io/cluster-issuer: letsencrypt

--- a/infrastructure/base/policies/resources.yaml
+++ b/infrastructure/base/policies/resources.yaml
@@ -40,6 +40,7 @@ spec:
         value:
         # Flux & Helm
         - helm.toolkit.fluxcd.io/v2beta1 HelmRelease
+        - kustomize.toolkit.fluxcd.io/v1beta2 Kustomization
         - notification.toolkit.fluxcd.io/v1beta2 Alert
         - notification.toolkit.fluxcd.io/v1beta2 Provider
         - source.toolkit.fluxcd.io/v1beta2 GitRepository

--- a/tests/policies/ingress/ingress.yaml
+++ b/tests/policies/ingress/ingress.yaml
@@ -4,6 +4,8 @@ kind: Ingress
 metadata:
   name: example-default-ingressclass
   namespace: ns
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
 spec:
   rules:
   - host: example.hsot
@@ -26,6 +28,8 @@ kind: Ingress
 metadata:
   name: example-ingressclass
   namespace: ns
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
 spec:
   ingressClass: haproxy
   rules:
@@ -51,6 +55,7 @@ metadata:
   namespace: ns
   annotations:
     kubernetes.io/ingress.class: haproxy
+    cert-manager.io/cluster-issuer: letsencrypt
 spec:
   rules:
   - host: example.hsot
@@ -73,10 +78,36 @@ kind: Ingress
 metadata:
   name: example-unknown-ingressclass
   namespace: ns
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
 spec:
   ingressClass: foo
   rules:
   - host: example.hsot
+    http:
+      paths:
+      - backend:
+          service:
+            name: example
+            port:
+              number: 8083
+        path: /
+        pathType: Prefix
+  tls:
+  - hosts:
+    - example-host
+    secretName: example-tls
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: example-unknown-cluster-issuer
+  namespace: ns
+  annotations:
+    cert-manager.io/cluster-issuer: invalid
+spec:
+  rules:
+  - host: example.host
     http:
       paths:
       - backend:

--- a/tests/policies/ingress/kyverno-test.yaml
+++ b/tests/policies/ingress/kyverno-test.yaml
@@ -20,6 +20,7 @@ results:
   result: fail
   resources:
   - example-unknown-ingressclass
+
 # Stop using deprecated annotations
 - policy: restrict-ingress-classes
   rule: forbid-ingress-annotations
@@ -34,3 +35,18 @@ results:
   result: fail
   resources:
   - example-with-annotation
+
+# Validate cluster issuer
+- policy: restrict-cluster-issuer
+  rule: validate-cluster-issuer
+  kind: Ingress
+  result: pass
+  resources:
+  - example-ingressclass
+  - example-default-ingressclass
+- policy: restrict-cluster-issuer
+  rule: validate-cluster-issuer
+  kind: Ingress
+  result: fail
+  resources:
+  - example-unknown-cluster-issuer


### PR DESCRIPTION
Add kyverno policy to verify certmanager annotations to catch mistakes with the wrong issuer name.