### PR TITLE
Enable kyverno tests on CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,4 +31,4 @@ jobs:
           kyverno test tests/policies/
       - name: Test cluster (flux-local)
         run: |
-          flux-local test --enable-helm
+          flux-local test --enable-helm --enable-kyverno --api-versions policy/v1/PodDisruptionBudget

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-flux-local==1.0.1
+flux-local==1.1.0
 pip==23.0.1
 pre-commit==3.1.1
 py==1.11.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-flux-local==1.1.0
+flux-local==1.1.1
 pip==23.0.1
 pre-commit==3.1.1
 py==1.11.0


### PR DESCRIPTION
Enable kyverno tests on CI, and set --api-versions so that some charts will create non-deprecated version resources.