### PR TITLE
Skip HR or KS diff when output is empty

### DIFF
--- a/.github/workflows/diff-kustomization.yaml
+++ b/.github/workflows/diff-kustomization.yaml
@@ -67,6 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - diffs
+    if: ${{ needs.diffs.outputs.ksdiff_output != [] }}
     strategy:
       matrix:
         kustomization: ${{ fromJson(needs.diffs.outputs.ksdiff_output) }}
@@ -111,6 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - diffs
+    if: ${{ needs.diffs.outputs.hrdiff_output != [] }}
     strategy:
       matrix:
         helmrelease: ${{ fromJson(needs.diffs.outputs.hrdiff_output) }}


### PR DESCRIPTION
Skip HR or KS diff when output is empty by checking for an empty array to avoid this error:
```
Error when evaluating 'strategy' for job 'kustomization'. .github/workflows/diff-kustomization.yaml (Line: 72, Col: 24): Matrix vector 'kustomization' does not contain any values
```