### PR TITLE
Force helm dashboard release updates to avoid blocking pvc

### DIFF
--- a/monitoring/base/helm-dashboard/release.yaml
+++ b/monitoring/base/helm-dashboard/release.yaml
@@ -19,6 +19,8 @@ spec:
   install:
     remediation:
       retries: 3
+  upgrade:
+    force: true  # Ensure old PVC is not holding
   test:
     enable: true
   # Default values


### PR DESCRIPTION
Force helm dashboard release updates to avoid blocking on previous pod holding the pvc during upgrade.