### PR TITLE
Explicitly set minecraft-07 disk storage

### DIFF
--- a/games/prod/minecraft-07-values.yaml
+++ b/games/prod/minecraft-07-values.yaml
@@ -56,6 +56,7 @@ spec:
     persistence:
       dataDir:
         enabled: true
+        Size: 10Gi
     resources:
       requests:
         memory: 8905Mi


### PR DESCRIPTION
Explicitly set minecraft-07 disk storage bumped to 10g