### PR TITLE
Disable wait on upgrade to avoid problems where service starts

### DIFF
--- a/games/prod/minecraft-proxy.yaml
+++ b/games/prod/minecraft-proxy.yaml
@@ -19,6 +19,8 @@ spec:
   install:
     remediation:
       retries: 3
+  upgrade:
+    disableWait: true
   test:
     # Fix problem where helm fails to uninstall
     enable: false


### PR DESCRIPTION
Will rely on monitoring of the service instead