### PR TITLE
Configure nodes with ipv6 configuration for matter server

### DIFF
--- a/plays/k8s.yaml
+++ b/plays/k8s.yaml
@@ -6,6 +6,7 @@
   - updates
   - common
   - packetloss
+  - matter-server
 
 - hosts: prx
   become: yes

--- a/roles/matter-server/tasks/main.yaml
+++ b/roles/matter-server/tasks/main.yaml
@@ -1,0 +1,3 @@
+---
+- name: Config systctl
+  import_tasks: sysctl.yaml

--- a/roles/matter-server/tasks/sysctl.yaml
+++ b/roles/matter-server/tasks/sysctl.yaml
@@ -8,6 +8,6 @@
     reload: true
   with_items:
     - name: net.ipv6.conf.eth0.accept_ra
-      value: 1
+      value: 0
     - name: net.ipv6.conf.eth0.accept_ra_rt_info_max_plen
       value: 64

--- a/roles/matter-server/tasks/sysctl.yaml
+++ b/roles/matter-server/tasks/sysctl.yaml
@@ -1,0 +1,13 @@
+---
+- name: Configure net.ipv6.config
+  ansible.posix.sysctl:
+    name: "{{ item.name }}"
+    value: "{{ item.value }}"
+    sysctl_set: true
+    state: present
+    reload: true
+  with_items:
+    - name: net.ipv6.conf.eth0.accept_ra
+      value: 1
+    - name: net.ipv6.conf.eth0.accept_ra_rt_info_max_plen
+      value: 64


### PR DESCRIPTION
Update with instructions from https://github.com/home-assistant-libs/python-matter-server for setting ipv6 flags. Updating k8s nodes in the hopes that this plus host network should be enough.