### PR TITLE
Update kyverno policy to not block on failure

### DIFF
--- a/infrastructure/base/policies/ingress.yaml
+++ b/infrastructure/base/policies/ingress.yaml
@@ -13,6 +13,7 @@ metadata:
       resource.
 spec:
   validationFailureAction: audit
+  failurePolicy: Ignore
   background: true
   rules:
   - name: forbid-ingress-annotations


### PR DESCRIPTION
Ensure that policy evaluation failures still allow the cluster to keep working. This is not a critical policy.