### PR TITLE
Add containerd configuration to normal kublet verification

### DIFF
--- a/roles/kubelet/tasks/containerd_config.yaml
+++ b/roles/kubelet/tasks/containerd_config.yaml
@@ -1,0 +1,27 @@
+---
+- name: Create containerd config directory
+  file:
+    path: /etc/containerd/
+    state: directory
+    owner: root
+    group: root
+    mode: '0655'
+
+
+- name: Default containerd config
+  command: containerd config default
+  register: default_config
+
+
+- name: Update containerd configuration
+  ansible.builtin.copy:
+    content: "{{default_config.stdout}}"
+    dest: /etc/containerd/config.toml
+  notify: restart containerd
+
+- name: Update SystemdCgroup
+  replace:
+    path: /etc/containerd/config.toml
+    regexp: "SystemdCgroup = false"
+    replace: "SystemdCgroup = true"
+  notify: restart containerd

--- a/roles/kubelet/tasks/main.yaml
+++ b/roles/kubelet/tasks/main.yaml
@@ -11,5 +11,8 @@
 - name: Packages
   import_tasks: packages.yaml
 
+- name: Containerd Config
+  import_tasks: containerd_config.yaml
+
 - name: Files
   import_tasks: files.yaml


### PR DESCRIPTION
Add containerd configuration to normal kublet verification to ensure hosts can be provisioned from scratch.