### PR TITLE
Increase nextcloud readiness probe timeouts

### DIFF
--- a/home/base/nextcloud/release.yaml
+++ b/home/base/nextcloud/release.yaml
@@ -38,3 +38,8 @@ spec:
       host: ${NEXTCLOUD_HOST}
       username: ${NEXTCLOUD_USERNAME}
       password: ${NEXTCLOUD_PASSWORD}
+    readinessProbe:
+      # Startup takes longer than expected for this chart
+      initialDelaySeconds: 60
+      periodSeconds: 60
+      failureThreshold: 5


### PR DESCRIPTION
Increase nextcloud readiness probe timeouts since it currently fails with:
```
Readiness probe failed: HTTP probe failed with statuscode: 400
```