### PR TITLE
Include full Helm chart spect to allow use of renovate OCI in redis

### DIFF
--- a/infrastructure/dev/redis-values.yaml
+++ b/infrastructure/dev/redis-values.yaml
@@ -7,9 +7,10 @@ spec:
   releaseName: redis
   chart:
     spec:
-      # renovate: registryUrl=oci://registry-1.docker.io/bitnamicharts
       chart: redis
       version: 17.11.3
+      # disabled by moving below chart/version
+      # renovate: registryUrl=oci://registry-1.docker.io/bitnamicharts
       sourceRef:
         kind: HelmRepository
         name: bitnami

--- a/infrastructure/dev/redis-values.yaml
+++ b/infrastructure/dev/redis-values.yaml
@@ -10,3 +10,7 @@ spec:
       # renovate: registryUrl=oci://registry-1.docker.io/bitnamicharts
       chart: redis
       version: 17.11.3
+      sourceRef:
+        kind: HelmRepository
+        name: bitnami
+        namespace: flux-system

--- a/infrastructure/prod/redis-values.yaml
+++ b/infrastructure/prod/redis-values.yaml
@@ -7,9 +7,10 @@ spec:
   releaseName: redis
   chart:
     spec:
-      # renovate: registryUrl=oci://registry-1.docker.io/bitnamicharts
       chart: redis
       version: 17.11.3
+      # disabled by moving below chart/version
+      # renovate: registryUrl=oci://registry-1.docker.io/bitnamicharts
       sourceRef:
         kind: HelmRepository
         name: bitnami

--- a/infrastructure/prod/redis-values.yaml
+++ b/infrastructure/prod/redis-values.yaml
@@ -10,3 +10,7 @@ spec:
       # renovate: registryUrl=oci://registry-1.docker.io/bitnamicharts
       chart: redis
       version: 17.11.3
+      sourceRef:
+        kind: HelmRepository
+        name: bitnami
+        namespace: flux-system

--- a/renovate.json5
+++ b/renovate.json5
@@ -17,7 +17,7 @@
         // Don't use for OCI repositories
         "infrastructure/dev/redis-values.yaml",
         "infrastructure/prod/redis-values.yaml",
-      ]
+      ],
       "matchStrings": [
         "registryUrl=(?<registryUrl>.*?)\n *chart: (?<depName>.*?)\n *version: (?<currentValue>.*)\n",
       ],

--- a/renovate.json5
+++ b/renovate.json5
@@ -13,6 +13,11 @@
       // tells renovate how to parse it. The annotation itself is added by the
       // renovate-helm-releases github action.
       "fileMatch": [".+\\.yaml$"],
+      "ignorePaths": [
+        // Don't use for OCI repositories
+        "infrastructure/dev/redis-values.yaml",
+        "infrastructure/prod/redis-values.yaml",
+      ]
       "matchStrings": [
         "registryUrl=(?<registryUrl>.*?)\n *chart: (?<depName>.*?)\n *version: (?<currentValue>.*)\n",
       ],

--- a/renovate.json5
+++ b/renovate.json5
@@ -13,11 +13,6 @@
       // tells renovate how to parse it. The annotation itself is added by the
       // renovate-helm-releases github action.
       "fileMatch": [".+\\.yaml$"],
-      "ignorePaths": [
-        // Don't use for OCI repositories
-        "infrastructure/dev/redis-values.yaml",
-        "infrastructure/prod/redis-values.yaml",
-      ],
       "matchStrings": [
         "registryUrl=(?<registryUrl>.*?)\n *chart: (?<depName>.*?)\n *version: (?<currentValue>.*)\n",
       ],


### PR DESCRIPTION
Update redis first as a test of the errors from #19

> Renovate failed to look up the following dependencies: Failed to look up helm package redis, Failed to look up helm package external-dns, Failed to look up helm package metallb.
> Files affected: infrastructure/dev/redis-values.yaml, infrastructure/prod/redis-values.yaml, services/dev/external-dns-values.yaml, services/dev/metallb-values.yaml, services/prod/external-dns-values.yaml, services/prod/metallb-values.yaml

Exclude redis from the custom renovate rules.