### PR TITLE
Update etcd version extraction for ansible role

### DIFF
--- a/roles/etcd/vars/main.yaml
+++ b/roles/etcd/vars/main.yaml
@@ -1,4 +1,4 @@
 ---
-# renovate: datasource=github-releases depName=etcd-io/etcd
+# renovate: datasource=github-releases depName=etcd-io/etcd extractVersion=^v(?<version>.+)
 etcd_version: 3.5.9
 download_url: https://storage.googleapis.com/etcd


### PR DESCRIPTION
Update etcd version extraction for ansible role to exclude the "v" to ensure renovate sets the right version in #1351