### PR TITLE
Upgrade snapshotter CRDs

### DIFF
--- a/crds/kustomization.yaml
+++ b/crds/kustomization.yaml
@@ -6,9 +6,9 @@ metadata:
   namespace: flux-system
 resources:
   # rook ceph
-  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-4.1/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
-  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-4.1/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
-  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-4.1/client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v6.2.0/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v6.2.0/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v6.2.0/client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml
   # Upgrade prometheus-operator crds ahead of kube-prometheus-stack
   - https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.69.1/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
   - https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.69.1/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml


### PR DESCRIPTION
This upgrades the CRDs to a newer version. The his path point to a versioned path that can be managed by renovate.

#1397 