### PR TITLE
Patch network config as a string

### DIFF
--- a/kubernetes/network/prod/load-balancer/metallb-ip-pool.yaml
+++ b/kubernetes/network/prod/load-balancer/metallb-ip-pool.yaml
@@ -5,7 +5,8 @@ metadata:
   name: generic-cluster-pool
   namespace: metallb
 spec:
-  addresses: ${service_ip_range}
+  addresses:
+  - ${service_ip_range}
 ---
 apiVersion: metallb.io/v1beta1
 kind: L2Advertisement

--- a/kubernetes/network/prod/network-config.yaml
+++ b/kubernetes/network/prod/network-config.yaml
@@ -6,8 +6,7 @@ metadata:
   namespace: flux-system
 data:
   # Loadbalancer (metallb)
-  service_ip_range:
-  - 10.10.102.1-10.10.102.254
+  service_ip_range: 10.10.102.1-10.10.102.254
   # Service Naming (k8s-gateway)
   name_service_dns_ip: 10.10.102.1
   name_service_dns_domain: k8s.mrv.thebends.org


### PR DESCRIPTION
Fails with the following error:
```
ConfigMap/flux-system/network-config dry-run failed: failed to create typed patch object (flux-system/network-config; /v1, Kind=ConfigMap): .data.service_ip_range: expected string, got &value.valueUnstructured{Value:[]interface {}{"10.10.102.1-10.10.102.254"}}                                                                    
```