### PR TITLE
Set letsencrypt config in the flux-system namespace

### DIFF
--- a/kubernetes/network/prod/certs.yaml
+++ b/kubernetes/network/prod/certs.yaml
@@ -20,5 +20,4 @@ spec:
   postBuild:
     substituteFrom:
     - kind: Secret
-      name: letsencrypt-config
-      namespace: cert-manager
+      name: network-secrets

--- a/kubernetes/network/prod/network-secrets.yaml
+++ b/kubernetes/network/prod/network-secrets.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: Secret
 metadata:
-    name: letsencrypt-config
-    namespace: cert-manager
+    name: network-secrets
+    namespace: flux-system
 type: Opaque
 stringData:
     cloud_project_id: ENC[AES256_GCM,data:bJdTkARcTOoYRbeEzwV/gSZv,iv:9YncngtM/zGWEd6Q8AesbEf8fdjEiRwb9DJTKh5E6d4=,tag:eflqylmeCG0aSTWGXZhN9g==,type:str]
@@ -22,8 +22,8 @@ sops:
             MDlzRmw5Mk44aWtWem16RnVhdFgzQjgKdT4VzSfUGLr4FIbfS+W/urNeuUxR3V1e
             C6vL4D0znN8JJTCrmikzUfYB3cQ/dzKu8wFPMJylcW4NH4N88SYFDw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2024-01-10T03:46:36Z"
-    mac: ENC[AES256_GCM,data:89XTuC9N28/XW4FHMTsF5bIhryqv/Nb8oIKDoihfJS/kyLon4Q7E0JS4uB5peBjyBBmHLEDbvRYzRB9c7QkBR9qTjLHe8XatTuPEMVWUmAPBUKgMq8ahG+lieIqVFh1nRuJtunKx9kDvSvu1Bnfw8xLWKE8mWNijyPTrYjarGDI=,iv:MqOOwTVbMmsYYnlBDa1jDktH5wJcrc3YRX3dgZpjxdk=,tag:SHl/+C1EbwxkbYfHGGXC0w==,type:str]
+    lastmodified: "2024-01-10T04:17:59Z"
+    mac: ENC[AES256_GCM,data:OAIIF5KnhRoNp4q2GnywowwfKsTNKLV9g+TBuIQRaqxEHehNG3sLfrkLD/uQZC5rJua+gD8EFIljhlOqHRQLiYG+vyZaBJ2C773CjwdfiyI0T2eF6yppa9nsOncmqtAI20F2VKwMItlfq4a+T/A+tWcoN09O4oKBBPGsIluLftc=,iv:lbtSHBJ4ZutFk5YTaoB9PrftlRvD7ziP6ROYigqAd5Y=,tag:Ww35Niy5Z0GtQNFODmHG9Q==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData)$
     version: 3.8.1


### PR DESCRIPTION
Put secret in the flux namespace, same as the kustomization to fix this error:
```
Kustomization/flux-system/network-certs dry-run failed: failed to create typed patch object (flux-system/network-certs; kustomize.toolkit.fluxcd.io/v1, Kind=Kustomization): .spec.postBuild.substituteFrom[0].namespace: field not declared in schema                                                                                                                                                                             
```

#1646