### PR TITLE
Update network config, and assign static ips for each

### DIFF
--- a/kubernetes/clusters/prod/network-config.yaml
+++ b/kubernetes/clusters/prod/network-config.yaml
@@ -10,5 +10,6 @@ data:
   # Service Naming (k8s-gateway)
   name_service_dns_ip: 10.10.102.1
   name_service_dns_domain: k8s.mrv.thebends.org
-  # External reverse proxy (nginx)
+  # Reverse proxies
   external_ingress_ip: 10.10.102.2
+  internal_ingress_ip: 10.10.102.3

--- a/kubernetes/network/prod/ingress/nginx-values.yaml
+++ b/kubernetes/network/prod/ingress/nginx-values.yaml
@@ -10,6 +10,10 @@ spec:
       # renovate: registryUrl=https://kubernetes.github.io/ingress-nginx
       chart: ingress-nginx
       version: 4.9.0
+  values:
+    controller:
+      service:
+        loadBalancerIP: ${internal_ingress_ip}
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease

--- a/netops/machinedb/machines.yaml
+++ b/netops/machinedb/machines.yaml
@@ -79,12 +79,21 @@ machines:
 - host: pelican
   ip: 10.10.100.1
   mac: 1c:69:7a:6d:2a:70
+  # Storage NIC:
+  #  iface: enx8cae4cd643b7
+  #  mac: 8c:ae:4c:d6:43:b7
 - host: sonar
   ip: 10.10.100.2
   mac: 1c:69:7a:6d:2a:b1
+  # Storage NIC:
+  #  iface: enx8cae4cd643c3
+  #  mac: 8c:ae:4c:d6:43:c3
 - host: buffalo
   ip: 10.10.100.3
   mac: 1c:69:7a:a6:f1:21
+  # Storage NIC:
+  #   iface: enx70bc108bdec5
+  #   mac: 70:bc:10:8b:de:c5
 - host: market
   ip: 10.10.100.4
   mac: e0:d5:5e:e5:25:be


### PR DESCRIPTION
Attempt to solve arp traffic flood

```
  Type     Reason            Age                    From                Message
  ----     ------            ----                   ----                -------
  Warning  AllocationFailed  59m (x4 over 59m)      metallb-controller  Failed to allocate IP for "nginx/nginx-external-ingress-nginx-controller": can't change sharing key for "nginx/nginx-external-ingress-nginx-controller", address also in use by nginx/nginx-ingress-nginx-controller
  Normal   ClearAssignment   59m                    metallb-controller  current IP for "nginx/nginx-external-ingress-nginx-controller" not allowed by config, will attempt for new IP assignment: can't change sharing key for "nginx/nginx-external-ingress-nginx-controller", address also in use by nginx/nginx-ingress-nginx-controller
  Normal   IPAllocated       41m                    metallb-controller  Assigned IP ["10.10.102.2"]
  Normal   nodeAssigned      81s (x34169 over 41m)  metallb-speaker     announcing from node "metal-2eaf" with protocol "layer2"
```