### PR TITLE
Perform substitution on hostnames in monitoring kustomization

### DIFF
--- a/kubernetes/clusters/prod/monitoring.yaml
+++ b/kubernetes/clusters/prod/monitoring.yaml
@@ -11,3 +11,7 @@ spec:
     name: flux-system
   path: ./kubernetes/monitoring/prod
   prune: true
+  postBuild:
+    substituteFrom:
+    - kind: ConfigMap
+      name: network-config


### PR DESCRIPTION
Fix error:
```
Ingress.extensions "weave-gitops" is invalid: [spec.rules[0].host: Invalid value: "w.${name_service_dns_domain}": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'), spec.tls[0].hosts[0]: Invalid value: "w.${name_service_dns_domain}": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')]                                              
```
#1646