### PR TITLE
Explicitly set ingressClassName on kube-prometheus-stack and rename cluster issuer

### DIFF
--- a/kubernetes/monitoring/base/kube-prometheus-stack/release.yaml
+++ b/kubernetes/monitoring/base/kube-prometheus-stack/release.yaml
@@ -28,6 +28,7 @@ spec:
       enabled: true
       ingress:
         enabled: true
+        ingressClassName: nginx-internal
         annotations:
           cert-manager.io/cluster-issuer: letsencrypt
         hosts:
@@ -87,6 +88,7 @@ spec:
     prometheus:
       ingress:
         enabled: true
+        ingressClassName: nginx-internal
         annotations:
           cert-manager.io/cluster-issuer: letsencrypt
         hosts:
@@ -120,6 +122,7 @@ spec:
     alertmanager:
       ingress:
         enabled: true
+        ingressClassName: nginx-internal
         annotations:
           cert-manager.io/cluster-issuer: letsencrypt
         hosts:

--- a/kubernetes/network/prod/certs/letsencrypt-issuer.yaml
+++ b/kubernetes/network/prod/certs/letsencrypt-issuer.yaml
@@ -2,7 +2,7 @@
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
-  name: letsencrypt-issuer
+  name: letsencrypt
   namespace: cert-manager
 spec:
   acme:


### PR DESCRIPTION
- Even though there is a default, it still expects an ingress class name.
- Also fixes: `Referenced "ClusterIssuer" not found: clusterissuer.cert-manager.io "letsencrypt" not found__`