### PR TITLE
Update nginx rules

### DIFF
--- a/kubernetes/monitoring/prod/kustomization.yaml
+++ b/kubernetes/monitoring/prod/kustomization.yaml
@@ -10,6 +10,5 @@ resources:
 - ../base/kubernetes-dashboard
 - ../base/kube-prometheus-stack
 - ../base/weave-gitops
-- flux-discord-urls-secret.yaml
 - monitoring-secrets.yaml
 - weave-gitops-secret.yaml

--- a/kubernetes/monitoring/prod/kustomization.yaml
+++ b/kubernetes/monitoring/prod/kustomization.yaml
@@ -10,5 +10,6 @@ resources:
 - ../base/kubernetes-dashboard
 - ../base/kube-prometheus-stack
 - ../base/weave-gitops
+- flux-discord-urls-secret.yaml
 - monitoring-secrets.yaml
 - weave-gitops-secret.yaml

--- a/kubernetes/network/base/nginx/prometheus-rules.yaml
+++ b/kubernetes/network/base/nginx/prometheus-rules.yaml
@@ -30,18 +30,18 @@ spec:
         summary: renew expiring certificates to avoid downtime
     # Updated rules to look at rates for the last minute, consistently failing for 30 minutes.
     - alert: NGINXTooMany500s
-      expr: 100 * (sum(rate(nginx_ingress_controller_requests{status=~"4.+"}[1m])) by (ingress) / sum(rate(nginx_ingress_controller_requests[1m])) by (ingress)) > 5
+      expr: 100 * (sum(rate(nginx_ingress_controller_requests{status=~"4.+"}[1m])) by (ingress) / sum(rate(nginx_ingress_controller_requests[1m])) by (ingress)) > 1
       for: 30m
       labels:
         severity: warning
       annotations:
         description: Too many 5XXs
-        summary: More than 5% of all requests returned 5XX, this requires your attention
+        summary: More than 1% of all requests returned 5XX, this requires your attention
     - alert: NGINXTooMany400s
-      expr: 100 * (sum(rate(nginx_ingress_controller_requests{status=~"4.+"}[1m])) by (ingress) / sum(rate(nginx_ingress_controller_requests[1m])) by (ingress)) > 5
+      expr: 100 * (sum(rate(nginx_ingress_controller_requests{status=~"4.+"}[1m])) by (ingress) / sum(rate(nginx_ingress_controller_requests[1m])) by (ingress)) > 1
       for: 30m
       labels:
         severity: warning
       annotations:
         description: Too many 4XXs
-        summary: More than 5% of all requests returned 4XX, this requires your attention
+        summary: More than 1% of all requests returned 4XX, this requires your attention

--- a/kubernetes/network/base/nginx/prometheus-rules.yaml
+++ b/kubernetes/network/base/nginx/prometheus-rules.yaml
@@ -28,17 +28,18 @@ spec:
       annotations:
         description: ssl certificate(s) will expire in less then a week
         summary: renew expiring certificates to avoid downtime
+    # Updated rules to look at rates for the last minute, consistently failing for 30 minutes.
     - alert: NGINXTooMany500s
-      expr: 100 * ( sum( nginx_ingress_controller_requests{status=~"5.+"} ) / sum(nginx_ingress_controller_requests) ) > 5
-      for: 1m
+      expr: 100 * (sum(rate(nginx_ingress_controller_requests{status=~"4.+"}[1m])) by (ingress) / sum(rate(nginx_ingress_controller_requests[1m])) by (ingress)) > 5
+      for: 30m
       labels:
         severity: warning
       annotations:
         description: Too many 5XXs
         summary: More than 5% of all requests returned 5XX, this requires your attention
     - alert: NGINXTooMany400s
-      expr: 100 * ( sum( nginx_ingress_controller_requests{status=~"4.+"} ) / sum(nginx_ingress_controller_requests) ) > 5
-      for: 1m
+      expr: 100 * (sum(rate(nginx_ingress_controller_requests{status=~"4.+"}[1m])) by (ingress) / sum(rate(nginx_ingress_controller_requests[1m])) by (ingress)) > 5
+      for: 30m
       labels:
         severity: warning
       annotations:


### PR DESCRIPTION
Update nginx rules since the existing rulest were not correct. They now compute an error rate over 1minute, and alert when failing for a longer period of time.