### PR TITLE
Add a GPU time slicing ClusterPolicy

### DIFF
--- a/bootstrap/flux/README.md
+++ b/bootstrap/flux/README.md
@@ -29,6 +29,10 @@ Before starting this step have:
     $ task --dir bootstrap/flux/ install-flux-system-ks
     ```
 
+1. Once the cluster is built, handle any custom hardware cluster policies.
+    ```
+    $ task --dir bootstrap/flux install-gpu-policy
+    ```
 
 ## References
 

--- a/bootstrap/flux/Taskfile.yaml
+++ b/bootstrap/flux/Taskfile.yaml
@@ -24,3 +24,8 @@ tasks:
   install-flux-system-ks:
     cmds:
       - kubectl apply -f ../../kubernetes/clusters/prod/flux-system/gotk-sync.yaml
+
+  install-gpu-policy:
+    # From https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/gpu-sharing.html#applying-one-cluster-wide-configuration
+    cmds:
+      - kubectl patch clusterpolicy/cluster-policy -n gpu-operator --type merge -p '{"spec": {"devicePlugin": {"config": {"name": "time-slicing-config", "default": "any"}}}}'

--- a/bootstrap/flux/Taskfile.yaml
+++ b/bootstrap/flux/Taskfile.yaml
@@ -26,6 +26,5 @@ tasks:
       - kubectl apply -f ../../kubernetes/clusters/prod/flux-system/gotk-sync.yaml
 
   install-gpu-policy:
-    # From https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/gpu-sharing.html#applying-one-cluster-wide-configuration
     cmds:
-      - kubectl patch clusterpolicy/cluster-policy -n gpu-operator --type merge -p '{"spec": {"devicePlugin": {"config": {"name": "time-slicing-config", "default": "any"}}}}'
+      - ./install-cpu-policy.sh

--- a/bootstrap/flux/install-gpu-policy.sh
+++ b/bootstrap/flux/install-gpu-policy.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+#
+# See https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/gpu-sharing.html#applying-one-cluster-wide-configuration
+
+set -e 
+
+kubectl patch clusterpolicy/cluster-policy \
+    -n gpu-operator --type merge \
+    -p '{"spec": {"devicePlugin": {"config": {"name": "time-slicing-config", "default": "any"}}}}'

--- a/kubernetes/clusters/manifest.yaml
+++ b/kubernetes/clusters/manifest.yaml
@@ -35,6 +35,8 @@ clusters:
     config_maps:
     - name: default-controller-env
       namespace: system-upgrade
+    - name: time-slicing-config
+      namespace: nvidia-gpu-operator
     secrets: []
   - name: crds
     namespace: flux-system

--- a/kubernetes/compute/prod/kustomization.yaml
+++ b/kubernetes/compute/prod/kustomization.yaml
@@ -12,3 +12,4 @@ resources:
 - ../base/node-feature-discovery
 - ../base/nvidia-gpu-operator
 - system-upgrade-controller
+- nvidia-time-slicing-config.yaml

--- a/kubernetes/compute/prod/nvidia-time-slicing-config.yaml
+++ b/kubernetes/compute/prod/nvidia-time-slicing-config.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: time-slicing-config
+  namespace: nvidia-gpu-operator
+data:
+  any: |-
+    version: v1
+    flags:
+      migStrategy: none
+    sharing:
+      timeSlicing:
+        resources:
+        - name: nvidia.com/gpu
+          replicas: 4


### PR DESCRIPTION
Add a GPU time slicing ClusterPolicy as configured by https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/gpu-sharing.html#applying-one-cluster-wide-configuration

#1648 