### PR TITLE
Add a service for the home assistant core devpod

### DIFF
--- a/kubernetes/iot/prod/devpod.yaml
+++ b/kubernetes/iot/prod/devpod.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: home-assistant-core
+  namespace: devpod
+spec:
+  selector:
+    allenporter/appname: home-assistant-core
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8123
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+  name: home-assistant-core
+  namespace: devpod
+spec:
+  ingressClassName: nginx-internal
+  rules:
+    - host: devpod-core.${name_service_dns_domain}
+      http:
+        paths:
+          - backend:
+              service:
+                name: home-assistant-core
+                port:
+                  number: 80
+            path: /
+            pathType: Prefix
+  tls:
+    - hosts:
+        - devpod-core.${name_service_dns_domain}
+      secretName: home-assistant-core-tls

--- a/kubernetes/iot/prod/kustomization.yaml
+++ b/kubernetes/iot/prod/kustomization.yaml
@@ -3,3 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - home-assistant
+- devpod.yaml


### PR DESCRIPTION
Expose a devpod instance on the local network, which is used for local home assistant development.