### PR TITLE
Update kubectl image in container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -58,7 +58,7 @@ RUN mkdir -p /usr/local/lib/ && \
     tar xf google-cloud-cli-${GCLOUD_CLI_VERSION}-linux-x86_64.tar.gz && \
     /usr/local/lib/google-cloud-sdk/install.sh --quiet --usage-reporting=false --rc-path=/etc/profile
 
-COPY --from=registry.k8s.io/kubectl:v1.34.1             /usr/local/bin/kubectl           /usr/local/bin/kubectl
+COPY --from=registry.k8s.io/kubectl:v1.34.1             /bin/kubectl                     /usr/local/bin/kubectl
 COPY --from=registry.k8s.io/kustomize/kustomize:v5.7.1  /app/kustomize                   /usr/local/bin/kustomize
 COPY --from=instrumentisto/restic:0.18.0-r2             /usr/local/bin/restic            /usr/local/bin/restic
 COPY --from=docker.io/alpine/helm:3.19.0                /usr/bin/helm                    /usr/local/bin/helm


### PR DESCRIPTION
Move to official image, away from bitnami image which doesn't exist anymore.