### PR TITLE
feat(talos): configure registry mirrors to cache OCI images

### DIFF
--- a/bootstrap/talos/talconf.yaml
+++ b/bootstrap/talos/talconf.yaml
@@ -131,3 +131,19 @@ patches:
      cluster:
        proxy:
          disabled: true
+  - |-
+     machine:
+       registries:
+         mirrors:
+           docker.io:
+             endpoints:
+               - https://registry.k8s.mrv.thebends.org
+               - https://registry-1.docker.io
+           ghcr.io:
+             endpoints:
+               - https://registry.k8s.mrv.thebends.org
+               - https://ghcr.io
+           mcr.microsoft.com:
+             endpoints:
+               - https://registry.k8s.mrv.thebends.org
+               - https://mcr.microsoft.com


### PR DESCRIPTION
This PR configures Talos containerd registry mirrors to point to our newly deployed in-cluster Zot registry for docker.io, ghcr.io, and mcr.microsoft.com.