### PR TITLE
feat(compute): deploy actions runner controller and scale set

### DIFF
--- a/kubernetes/clusters/prod/compute.yaml
+++ b/kubernetes/clusters/prod/compute.yaml
@@ -13,3 +13,7 @@ spec:
   prune: true
   dependsOn:
   - name: flux-system
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age

--- a/kubernetes/clusters/prod/sources/actions-runner-controller.yaml
+++ b/kubernetes/clusters/prod/sources/actions-runner-controller.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: actions-runner-controller-charts
+  namespace: flux-system
+spec:
+  interval: 2h
+  type: oci
+  url: oci://ghcr.io/actions/actions-runner-controller-charts

--- a/kubernetes/clusters/prod/sources/kustomization.yaml
+++ b/kubernetes/clusters/prod/sources/kustomization.yaml
@@ -25,3 +25,4 @@ resources:
   - tailscale.yaml
   - headlamp.yaml
   - zot.yaml
+  - actions-runner-controller.yaml

--- a/kubernetes/compute/base/actions-runner-controller/kustomization.yaml
+++ b/kubernetes/compute/base/actions-runner-controller/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: arc-systems
+resources:
+  - namespace.yaml
+  - release.yaml

--- a/kubernetes/compute/base/actions-runner-controller/namespace.yaml
+++ b/kubernetes/compute/base/actions-runner-controller/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: arc-systems

--- a/kubernetes/compute/base/actions-runner-controller/release.yaml
+++ b/kubernetes/compute/base/actions-runner-controller/release.yaml
@@ -8,6 +8,7 @@ spec:
   chart:
     spec:
       chart: gha-runner-scale-set-controller
+      version: ">=0.1.0"
       sourceRef:
         kind: HelmRepository
         name: actions-runner-controller-charts

--- a/kubernetes/compute/base/actions-runner-controller/release.yaml
+++ b/kubernetes/compute/base/actions-runner-controller/release.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: gha-runner-scale-set-controller
-      version: ">=0.1.0"
+      version: 0.14.2
       sourceRef:
         kind: HelmRepository
         name: actions-runner-controller-charts

--- a/kubernetes/compute/base/actions-runner-controller/release.yaml
+++ b/kubernetes/compute/base/actions-runner-controller/release.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: gha-runner-scale-set-controller
+spec:
+  releaseName: gha-runner-scale-set-controller
+  chart:
+    spec:
+      chart: gha-runner-scale-set-controller
+      sourceRef:
+        kind: HelmRepository
+        name: actions-runner-controller-charts
+        namespace: flux-system
+  interval: 1h0m0s
+  install:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  upgrade:
+    crds: CreateReplace
+  values:
+    replicaCount: 1

--- a/kubernetes/compute/base/actions-runner-scale-set/kustomization.yaml
+++ b/kubernetes/compute/base/actions-runner-scale-set/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: arc-systems
+resources:
+  - release.yaml

--- a/kubernetes/compute/base/actions-runner-scale-set/release.yaml
+++ b/kubernetes/compute/base/actions-runner-scale-set/release.yaml
@@ -8,6 +8,7 @@ spec:
   chart:
     spec:
       chart: gha-runner-scale-set
+      version: ">=0.1.0"
       sourceRef:
         kind: HelmRepository
         name: actions-runner-controller-charts

--- a/kubernetes/compute/base/actions-runner-scale-set/release.yaml
+++ b/kubernetes/compute/base/actions-runner-scale-set/release.yaml
@@ -20,6 +20,9 @@ spec:
   values:
     githubConfigUrl: "https://github.com/allenporter/k8s-gitops"
     githubConfigSecret: github-app-credentials
+    controllerServiceAccount:
+      namespace: arc-systems
+      name: gha-runner-scale-set-controller
     minRunners: 0
     maxRunners: 5
     containerMode:

--- a/kubernetes/compute/base/actions-runner-scale-set/release.yaml
+++ b/kubernetes/compute/base/actions-runner-scale-set/release.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: gha-runner-scale-set
-      version: ">=0.1.0"
+      version: 0.14.2
       sourceRef:
         kind: HelmRepository
         name: actions-runner-controller-charts

--- a/kubernetes/compute/base/actions-runner-scale-set/release.yaml
+++ b/kubernetes/compute/base/actions-runner-scale-set/release.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: gha-runner-scale-set
+spec:
+  releaseName: gha-runner-scale-set
+  chart:
+    spec:
+      chart: gha-runner-scale-set
+      sourceRef:
+        kind: HelmRepository
+        name: actions-runner-controller-charts
+        namespace: flux-system
+  interval: 1h0m0s
+  install:
+    remediation:
+      retries: 3
+  values:
+    githubConfigUrl: "https://github.com/allenporter/k8s-gitops"
+    githubConfigSecret: github-app-credentials
+    minRunners: 0
+    maxRunners: 5
+    containerMode:
+      type: "dind"

--- a/kubernetes/compute/prod/actions-runner-controller-values.yaml
+++ b/kubernetes/compute/prod/actions-runner-controller-values.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: gha-runner-scale-set-controller
+  namespace: arc-systems
+spec:
+  chart:
+    spec:
+      chart: gha-runner-scale-set-controller
+      version: 0.14.2
+      sourceRef:
+        kind: HelmRepository
+        name: actions-runner-controller-charts
+        namespace: flux-system

--- a/kubernetes/compute/prod/actions-runner-scale-set-values.yaml
+++ b/kubernetes/compute/prod/actions-runner-scale-set-values.yaml
@@ -16,6 +16,9 @@ spec:
   values:
     githubConfigUrl: "https://github.com/allenporter"
     githubConfigSecret: github-app-credentials
+    controllerServiceAccount:
+      namespace: arc-systems
+      name: gha-runner-scale-set-controller
     minRunners: 0
     maxRunners: 5
     containerMode:

--- a/kubernetes/compute/prod/actions-runner-scale-set-values.yaml
+++ b/kubernetes/compute/prod/actions-runner-scale-set-values.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: gha-runner-scale-set
+  namespace: arc-systems
+spec:
+  chart:
+    spec:
+      chart: gha-runner-scale-set
+      version: 0.14.2
+      sourceRef:
+        kind: HelmRepository
+        name: actions-runner-controller-charts
+        namespace: flux-system
+  values:
+    githubConfigUrl: "https://github.com/allenporter"
+    githubConfigSecret: github-app-credentials
+    minRunners: 0
+    maxRunners: 5
+    containerMode:
+      type: "dind"

--- a/kubernetes/compute/prod/github-app-credentials.sops.yaml
+++ b/kubernetes/compute/prod/github-app-credentials.sops.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: github-app-credentials
+    namespace: arc-systems
+type: Opaque
+stringData:
+    github_app_id: ENC[AES256_GCM,data:UElR2JYD5w==,iv:aeU13v9rwheybWy81KNPLrpS9OPu4QyoTu7fkQ3PLRU=,tag:GVBb4qjEhU+0z2H1EOlMTg==,type:str]
+    github_app_installation_id: ENC[AES256_GCM,data:Eab+xzi3ICsa,iv:X0WmlpTZLVCeQwA/D1MsKuE1Ig2u0Dj1YLsaUeZLpbw=,tag:wWh0eKPBft/bA/km3iBBOw==,type:str]
+    github_app_private_key: ENC[AES256_GCM,data:gF/3kM76SaGOYgEd0vx/wv6wRFlxIvKH6Q4gYe2tWObkjkjXUeVolgT0VeT3bAeDSObK6XwkLxbxpj6s0/qc9kt1lg7lTkPnWxL/Jgq7atPLowqAftIGvr03TU4ZA17V7qny+TBZoCeys9fDV8qQ3zyMyj7YEleqBhIl1NAGcb5qMWaXGL+zoJszotCsawOAsgRxU4GaGsTkDQH6cqklfcw+JLTIQ9A/NLqsoEFGuvC/BA/lc0lhCrWaYwpCQEK08mWjUn7FCyj97QBBFiiINRR4VvFO5DyOHEXDjebk3KTfkSAPiWHAk4QP8LF48CtaHLG9K0EFenUEaOOdPh7qOK1GX+66BNUfZd3u0vY0L+twgZJALOSHErxST/gGInirTDwjm8hNLTnBf0+XAmGbTT7mIrmNCR2Zs74h5sVX+O5xH1VqDCdr5Huiie7Uot4enfXS0J5LaMGQ2QYqsG/cxYecKvy+gvjtVKrshRrOhdx3KJorgl1uDRXHNY/FV+AOU7zP0eue6I6GqoGdZCxwQ0e6jTNvzOf68rBNfmQqNazhydShx6JR45AEI4B6/eS2/QD691+enZr/FVqsQQpPKk4jfpFWkFDgH1NrtBwPmvqg3VOIYUYxI6YnFgP9hQU4fGrXOxUadzYoqpbkmlaMmYOFt9y454hJAmqyTmpRiHJz1AFgwZw41FOkxOZT54tkL3gTM+dejNQrwr89xdU6bHkWVaTovdURM1v3iJjGJrdTEbuwyTAIXEu7fqXVd8yfQlKAJinJ193CKXgfAGZTamInWcbpBEKYbm1R9iiQpWbB/5qH3y6J+RAP2b6TdKkmHoqHDlyB5KVM5P3OHNojSDU0lgWL6tnalrhlFXXQXdmvSifYr9KlUlWKl14E+3eCbXH1jBxhNkV6GYXaf7wum34JLojQdUS0ud/8EkD6l7CPRdecbkeooVtP5H22OCkz2Cp9EQdJdBKGXteaO9zpBVh79o7xhQErgC9Ejsb2so0Ki3qVjTuxF0KZ/SmkMcdxdylaBTbuTKbiMq+PLYZnj03pbgIMdxOuRn70gCfCvAMO+nXFo2FcUrlIC1fCfJ5Kq1H1IqohlPCpSDCn/4/fE5yh1RKNljG+BeXNihBexrw+5aH/VURBroLIPkmVcEYAP6diE4fFy4RpcK9W3EU4t3xjNAraPVp7dZvuebW09cjhw0ItXFM+nqqaAnDe22gWu/iYDUKygt54kLZticGwdE7H0L23RxHz+jBb6UXvZLSOInh2St/EHG2rTU6UMbbASsXwRxgWs2lwJtx8MqbT160hBiYida04jjH8VqnOllUTlzGD/xAduDYgqe4gOY/Kf9Vt+I2u53+APp6IZzeji0k8TRyvPDf9ksb4wJeI6uRKSRfoLGb1fy1ol0ZEf1u/9PU9SdrmPRi2VQ0HSjxoqjlRAoMLyKI+Bj5BnYzcsuaGuVRv85CPRqPcSYLbLVTtaNqMBA4zWIB1VrWf/T8BCsTZUqwLViDooEkbY1KtSQt0meKa0bKM8O66y7AGJ+NQT/sF+y90PTvIOOOPg9heIkZuCbj+DSia44O+Hk4BvvzaBPZBe0otKQ5pxv1xnLi7rJGytgUJOjvO3Chv5Jdsui4Ff9H3shHVgneC1Sndn7LpU2boLES0sbMvPDjq9077RzIpt2a24rGUYFZCuOqwQxhXEZvV13ic+Mtjn1gR/63LYbeprK3HmcItu6MQ7X/xbcynY0sSu/8imVErQ1ZwkAoGojeMRzfyWkJhP64RiQ6Cpzwb8nhW1BrXZb0kQy3ME5v7+LN9fvqAjO0kM4Yoq7blpuv5cHntURYZ/DOU2sfOjAXrcj913+fyJlePnDqLO2wbZFlM46cFlZte8k73y3RpO6/+R2o1ymJuWHVaeEVHwgYDdsWvF0USHx7RxpXPaE3MTw2ti9MQuSvfr6/AdK1fZ+7+lNsmI/XI7e/LWsawMtKiGVwc+U7z4TFlvY4WL1GKeXm2aMl+sldfHOoeWxiAE53iGmKadaSb0jxTZKmnWTbU9CPZ7FKztaTnblbnYp1kjazLq3DJ8IrMPv5WOeLJU00SEigT4YfgfBlFCRFnAmiW9xmpJjHcbdeSfR7Fj0v1qAlhAmxjE0HoLEZ4SZdJKsk7u5+ldAEfq7pGegeARRZEahxvlaxLi76libICU9xDtQXmxmknMKN/IMsnVM9JGasAID2VJo9FtMF8yYHRl7YsyIwoLfzRWA==,iv:lB79GSHo3MxX7ZRbt/LvSHcyPFkxO2Tij3SeD1NO8dU=,tag:Uv1micLcgfZD8C2p+kjAJQ==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA2NUJSRDhLS2poVjhRTkdo
+            R3ErY21aWjRBRktCclJCejVVS1B0WlY1aEFJCm9BVzdWdWFpOUFHWUJXa0ZIb1hG
+            ZEtWckJPR1JsSnArd1dhY0xQNW9wTTQKLS0tIFh6WHI0ZWFGQWhlZ2F6YWZudmpo
+            TU5uM0wvTk9OWVRvaG0vcW9LM1RhaTgK/6GoqdxZGrbir3rzrJR5JoKxTrQhE3sh
+            KImenB0sFQ5zr8x28TsWeCydc9BKF1M5AUQXkCQaH5pzuwe4GjE24A==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1neakthxhftzns63tmvmpsn0rl4wfzzhsdcucm0a84et24azgxdyqrkagxg
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-07-12T04:32:50Z"
+    mac: ENC[AES256_GCM,data:iBH4eneC/qiLEl2J6w2E/Cd33/B5Sr/BB4vtyGhqN+elYaTq3IaM2dbrlis3LTitGjb/bWkEYgeGl0+TlnbeI+r0dq8HqSUqDO5oSJrtFLPYBoiFC2uE5EgG9QAaJw4/d1p9uUPviNCQaU2ACpaJ1QNUKGc1wvkVZYR3/CYkHz8=,iv:XF934EWG4Lmn2DFHbQAzvkdDZPnxKA+gpYFjzbGiEk4=,tag:q2JqEEW63slS1EBX8z8MtQ==,type:str]
+    version: 3.13.1

--- a/kubernetes/compute/prod/kustomization.yaml
+++ b/kubernetes/compute/prod/kustomization.yaml
@@ -17,3 +17,4 @@ resources:
 - ../base/actions-runner-scale-set
 - system-upgrade-controller
 - nvidia-time-slicing-config.yaml
+- github-app-credentials.sops.yaml

--- a/kubernetes/compute/prod/kustomization.yaml
+++ b/kubernetes/compute/prod/kustomization.yaml
@@ -6,10 +6,14 @@ patches:
 - path: intel-device-plugin-gpu-values.yaml
 - path: node-feature-discovery-values.yaml
 - path: nvidia-device-plugin-values.yaml
+- path: actions-runner-controller-values.yaml
+- path: actions-runner-scale-set-values.yaml
 resources:
 - ../base/intel-device-plugin
 - ../base/intel-device-plugin-gpu
 - ../base/node-feature-discovery
 - ../base/nvidia-device-plugin
+- ../base/actions-runner-controller
+- ../base/actions-runner-scale-set
 - system-upgrade-controller
 - nvidia-time-slicing-config.yaml


### PR DESCRIPTION
This PR deploys GitHub Actions Runner Controller (ARC) and a self-hosted runner scale set targeting the https://github.com/allenporter organization. Runners run in rootless DinD mode for compiling container images.