### PR TITLE
chore: install flate in dev environment and bootstrap

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -60,6 +60,7 @@ COPY --from=registry.k8s.io/kustomize/kustomize:v5.8.1  /app/kustomize          
 COPY --from=instrumentisto/restic:0.18.1-r2             /usr/local/bin/restic            /usr/local/bin/restic
 COPY --from=docker.io/alpine/helm:4.2.3                /usr/bin/helm                    /usr/local/bin/helm
 COPY --from=ghcr.io/fluxcd/flux-cli:v2.9.1              /usr/local/bin/flux              /usr/local/bin/flux
+COPY --from=ghcr.io/home-operations/flate:0.4.10         /flate                           /usr/local/bin/flate
 COPY --from=ghcr.io/siderolabs/talosctl:v1.13.6          /talosctl                        /usr/local/bin/talosctl
 
 ARG TARGETARCH

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -60,6 +60,13 @@ if command -v brew >/dev/null 2>&1; then
     fi
   fi
 
+  # Tap and install home-operations/tap/flate
+  if ! brew list --cask home-operations/tap/flate >/dev/null 2>&1 && ! command -v flate >/dev/null 2>&1; then
+    echo "==> Tapping home-operations/tap and installing flate..."
+    brew tap home-operations/tap
+    brew install --cask home-operations/tap/flate
+  fi
+
   # Install Google Cloud CLI Cask if missing
   if ! brew list --cask google-cloud-sdk >/dev/null 2>&1 && ! command -v gcloud >/dev/null 2>&1; then
     echo "==> Installing google-cloud-sdk cask..."


### PR DESCRIPTION
This PR installs the new flate CLI (replacing flux-local) in both the local Homebrew bootstrap script and the devcontainer Dockerfile.