### PR TITLE
upgrade(k8s): bump kubernetesVersion to v1.36.2

### DIFF
--- a/bootstrap/talos/talconf.yaml
+++ b/bootstrap/talos/talconf.yaml
@@ -1,7 +1,7 @@
 ---
 clusterName: k8s-cluster
 talosVersion: v1.13.6
-kubernetesVersion: v1.35.6
+kubernetesVersion: v1.36.2
 endpoint: https://10.10.101.1:6443
 allowSchedulingOnMasters: true
 allowSchedulingOnControlPlanes: true


### PR DESCRIPTION
Bumps Kubernetes version globally to v1.36.2 in talconf.yaml.

Issue #2431