### PR TITLE
chore(renovate): restrict immediate supernote updates to minor, patch, and digest

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -176,6 +176,11 @@
       matchPackageNames: [
         'ghcr.io/allenporter/supernote',
       ],
+      matchUpdateTypes: [
+        'minor',
+        'patch',
+        'digest',
+      ],
       schedule: [],
       minimumReleaseAge: '0 days',
       automerge: true,


### PR DESCRIPTION
Restricts immediate, automerged Renovate updates for supernote to minor, patch, and digest versions, while keeping major updates on the standard weekly schedule.