### PR TITLE
chore(supernote): bump image tag to v0.14.9

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -176,6 +176,11 @@
       matchPackageNames: [
         'ghcr.io/allenporter/supernote',
       ],
+      matchUpdateTypes: [
+        'minor',
+        'patch',
+        'digest',
+      ],
       schedule: [],
       minimumReleaseAge: '0 days',
       automerge: true,

--- a/kubernetes/iot/prod/supernote/release.yaml
+++ b/kubernetes/iot/prod/supernote/release.yaml
@@ -36,7 +36,7 @@ spec:
           main:
             image:
               repository: ghcr.io/allenporter/supernote
-              tag: v0.14.8
+              tag: v0.14.9
 
             env:
               - name: SUPERNOTE_PROXY_MODE


### PR DESCRIPTION
Bumps supernote container image tag to v0.14.9.