### PR TITLE
fix: resolve flate warnings and bump flate to v0.5.0

### DIFF
--- a/kubernetes/clusters/prod/cni/cilium-values.yaml
+++ b/kubernetes/clusters/prod/cni/cilium-values.yaml
@@ -23,7 +23,7 @@ spec:
     ipam:
       mode: kubernetes
     kubeProxyReplacement: true
-    ubeProxyReplacementHealthzBindAddr: 0.0.0.0:10256
+    kubeProxyReplacementHealthzBindAddr: 0.0.0.0:10256
     k8sServiceHost: 127.0.0.1
     k8sServicePort: 7445
     l2announcements:

--- a/kubernetes/storage/base/rook-ceph/release.yaml
+++ b/kubernetes/storage/base/rook-ceph/release.yaml
@@ -23,7 +23,5 @@ spec:
   values:
     crds:
       enabled: true
-    serviceMonitor:
-      enabled: true
     monitoring:
       enabled: true


### PR DESCRIPTION
### Summary
- Fix Cilium CNI values typo `ubeProxyReplacementHealthzBindAddr` -> `kubeProxyReplacementHealthzBindAddr` in `kubernetes/clusters/prod/cni/cilium-values.yaml`
- Remove redundant `serviceMonitor:` block in `kubernetes/storage/base/rook-ceph/release.yaml` (chart uses `monitoring.enabled: true`)
- Bump `home-operations/flate/action` to `v0.5.0` in CI workflows (`.github/workflows/test.yaml` and `.github/workflows/diff-kustomization.yaml`)
- Bump `ghcr.io/home-operations/flate` image tag to `0.5.0` in `.devcontainer/Dockerfile`